### PR TITLE
VB-5084 - Allow SQS message handling for domain events

### DIFF
--- a/.github/workflows/setup-and-validate.yml
+++ b/.github/workflows/setup-and-validate.yml
@@ -21,6 +21,16 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
+      localstack:
+        image: localstack/localstack:latest
+        env:
+          SERVICES: sqs, sns
+          DEFAULT_REGION: us-east-1
+          AWS_ACCESS_KEY_ID: test
+          AWS_SECRET_ACCESS_KEY: test
+        ports:
+          - 4566:4566
+          - 4571:4571
       postgres:
         image: postgres:15.7
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .gradle/
 .kotlin/
 build/
+volume/
 
 # CMake
 cmake-build-debug/

--- a/README.md
+++ b/README.md
@@ -70,3 +70,36 @@ Call info endpoint:
 ```
 $ curl 'http://localhost:8081/info' -i -X GET
 ```
+
+### Send event notifications locally (AWS SNS, SQS / LocalStack)
+To help test notification events locally we can send events to localstack to replicate what NOMIS would do.
+
+#### Step 1 - Start visit-allocation-api service locally
+Follow steps for set-up / running at top of README
+
+#### Step 2 - Install awscli (if not already installed)
+```
+brew install awscli
+```
+
+#### Step 3 - configure aws with dummy values (if not already configured)
+```
+aws configure
+```
+Put any dummy value for AWS_ACCESS_KEY=test and AWS_SECRET_KEY=test and eu-west-2 as default region.
+The queueName is the value of hmpps.sqs.queues.prisonvisitsallocationevents.queueName on the application-<env>.yml file.
+So the queue URL should be - http://localhost:4566/000000000000/{queueName}
+
+#### Step 4 - Send a message to the queue. The below is a prisoner.conviction-status-updated event for prisoner A8713DY.
+```
+aws sqs send-message \
+  --endpoint-url=http://localhost:4566 \
+  --queue-url=http://localhost:4566/000000000000/sqs_hmpps_visits_allocation_events_queue \
+  --message-body \
+    '{"Type":"Notification", "Message": "{\"eventType\":\"prisoner-offender-search.prisoner.conviction-status.updated\",\"additionalInformation\":{\"NomsNumber\":\"A8713DY\", "MessageId": "123"}'
+```
+
+If you are unsure about the queue name you can check the queue names using the following command and replace it in the above --queue-url value parameter
+```
+aws sqs list-queues --endpoint-url=http://localhost:4566
+```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Run:
 ## Running
 
 The hmpps-visit-allocation-api uses the deployed dev environment to connect to most of the required services,
-with an exception of the visit-allocation-db.
+with the exception of the visit-allocation-db and localstack (for AWS SNS/SQS services locally).
 
 To run the hmpps-visit-allocation-api, first start the required local services using docker-compose.
 
@@ -46,6 +46,7 @@ Ports
 |----------------------------|------|
 | hmpps-visit-allocation-api | 8079 |
 | visit-allocation-db        | 5445 |
+| localstack                 | 4566 |
 
 ### Populating local Db with data
 TODO
@@ -68,7 +69,7 @@ Client Authentication: "Send as Basic Auth Header"
 
 Call info endpoint:
 ```
-$ curl 'http://localhost:8081/info' -i -X GET
+$ curl 'http://localhost:8079/info' -i -X GET
 ```
 
 ### Send event notifications locally (AWS SNS, SQS / LocalStack)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,11 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:5.2.2")
+
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-jdk8")
+  implementation("io.opentelemetry:opentelemetry-extension-kotlin")
 
   runtimeOnly("org.postgresql:postgresql:42.7.4")
   runtimeOnly("org.flywaydb:flyway-core")
@@ -23,6 +28,8 @@ dependencies {
   testImplementation("io.swagger.parser.v3:swagger-parser:2.1.24") {
     exclude(group = "io.swagger.core.v3")
   }
+  testImplementation("org.testcontainers:localstack:1.20.4")
+  testImplementation("org.awaitility:awaitility-kotlin:4.2.2")
 }
 
 kotlin {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,5 +12,18 @@ services:
       - POSTGRES_PASSWORD=visit_allocation
       - POSTGRES_USER=visit_allocation
       - POSTGRES_DB=visit_allocation
+
+  localstack:
+    image: localstack/localstack:3
+    networks:
+      - hmpps
+    container_name: localstack-hmpps-visit-allocation-alerts
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sqs,sns
+      - DEFAULT_REGION=eu-west-2
+    volumes:
+      - "${LOCALSTACK_VOLUME_DIR:-./volume}:/var/lib/localstack"
 networks:
   hmpps:

--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -33,10 +33,10 @@ generic-service:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
     hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
-    sqs-prison-visits-allocation-alerts-secret:
-      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONALERTS_QUEUE_NAME: "sqs_queue_name"
-    sqs-hmpps-prison-visits-allocation-alerts-dlq-secret:
-      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONALERTS_DLQ_NAME: "sqs_queue_name"
+    sqs-prison-visits-allocation-events-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONEVENTS_QUEUE_NAME: "sqs_queue_name"
+    sqs-hmpps-prison-visits-allocation-events-dlq-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONEVENTS_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -31,6 +31,12 @@ generic-service:
       DATABASE_ENDPOINT: "rds_instance_endpoint"
     application-insights:
       APPLICATIONINSIGHTS_CONNECTION_STRING: "APPLICATIONINSIGHTS_CONNECTION_STRING"
+    hmpps-domain-events-topic:
+      HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"
+    sqs-prison-visits-allocation-alerts-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONALERTS_QUEUE_NAME: "sqs_queue_name"
+    sqs-hmpps-prison-visits-allocation-alerts-dlq-secret:
+      HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONALERTS_DLQ_NAME: "sqs_queue_name"
 
   allowlist:
     groups:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -19,3 +19,8 @@ generic-service:
 generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: visits-alerts-nonprod
+  sqsAlertsQueueNames:
+    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_alerts_queue"
+    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_alerts_dlq"
+  sqsAlertsOldestThreshold: 1
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,7 @@ generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: visits-alerts-nonprod
   sqsAlertsQueueNames:
-    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_alerts_queue"
-    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_alerts_dlq"
+    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_events_queue"
+    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_events_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,7 +16,7 @@ generic-service:
 generic-prometheus-alerts:
   alertSeverity: visits-alerts-nonprod
   sqsAlertsQueueNames:
-    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_alerts_queue"
-    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_alerts_dlq"
+    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_events_queue"
+    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_events_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,3 +15,8 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: visits-alerts-nonprod
+  sqsAlertsQueueNames:
+    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_alerts_queue"
+    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_alerts_dlq"
+  sqsAlertsOldestThreshold: 1
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -12,3 +12,8 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: visits-alerts
+  sqsAlertsQueueNames:
+    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_alerts_queue"
+    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_alerts_dlq"
+  sqsAlertsOldestThreshold: 1
+  sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -13,7 +13,7 @@ generic-service:
 generic-prometheus-alerts:
   alertSeverity: visits-alerts
   sqsAlertsQueueNames:
-    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_alerts_queue"
-    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_alerts_dlq"
+    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_events_queue"
+    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_events_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -20,7 +20,7 @@ generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: visits-alerts-nonprod
   sqsAlertsQueueNames:
-    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_alerts_queue"
-    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_alerts_dlq"
+    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_events_queue"
+    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_events_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -19,3 +19,8 @@ generic-service:
 generic-prometheus-alerts:
   businessHoursOnly: true
   alertSeverity: visits-alerts-nonprod
+  sqsAlertsQueueNames:
+    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_alerts_queue"
+    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_alerts_dlq"
+  sqsAlertsOldestThreshold: 1
+  sqsAlertsTotalMessagesThreshold: 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/AuthAwareTokenConverter.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/AuthAwareTokenConverter.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.config
+
+import org.springframework.core.convert.converter.Converter
+import org.springframework.security.authentication.AbstractAuthenticationToken
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+
+class AuthAwareTokenConverter : Converter<Jwt, AbstractAuthenticationToken> {
+  private val jwtGrantedAuthoritiesConverter: Converter<Jwt, Collection<GrantedAuthority>> =
+    JwtGrantedAuthoritiesConverter()
+
+  override fun convert(jwt: Jwt): AbstractAuthenticationToken {
+    val claims = jwt.claims
+    val principal = findPrincipal(claims)
+    val authorities = extractAuthorities(jwt)
+
+    return AuthAwareAuthenticationToken(jwt, principal, authorities)
+  }
+
+  private fun findPrincipal(claims: Map<String, Any?>): String {
+    return if (claims.containsKey(CLAIM_USERNAME)) {
+      claims[CLAIM_USERNAME] as String
+    } else if (claims.containsKey(CLAIM_USER_ID)) {
+      claims[CLAIM_USER_ID] as String
+    } else {
+      claims[CLAIM_CLIENT_ID] as String
+    }
+  }
+
+  private fun extractAuthorities(jwt: Jwt): Collection<GrantedAuthority> {
+    val authorities = mutableListOf<GrantedAuthority>().apply { addAll(jwtGrantedAuthoritiesConverter.convert(jwt)!!) }
+    if (jwt.claims.containsKey(CLAIM_AUTHORITY)) {
+      @Suppress("UNCHECKED_CAST")
+      val claimAuthorities = (jwt.claims[CLAIM_AUTHORITY] as Collection<String>).toList()
+      authorities.addAll(claimAuthorities.map(::SimpleGrantedAuthority))
+    }
+    return authorities.toSet()
+  }
+
+  companion object {
+    const val CLAIM_USERNAME = "user_name"
+    const val CLAIM_USER_ID = "user_id"
+    const val CLAIM_CLIENT_ID = "client_id"
+    const val CLAIM_AUTHORITY = "authorities"
+  }
+}
+
+class AuthAwareAuthenticationToken(
+  jwt: Jwt,
+  private val aPrincipal: String,
+  authorities: Collection<GrantedAuthority>,
+) : JwtAuthenticationToken(jwt, authorities) {
+  override fun getPrincipal(): String {
+    return aPrincipal
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/ResourceServerConfiguration.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.annotation.web.invoke
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity(prePostEnabled = true, proxyTargetClass = true)
+@EnableCaching
+class ResourceServerConfiguration {
+  @Throws(Exception::class)
+  @Bean
+  fun filterChain(http: HttpSecurity): SecurityFilterChain {
+    http {
+      headers { frameOptions { sameOrigin = true } }
+      sessionManagement { sessionCreationPolicy = SessionCreationPolicy.STATELESS }
+      // Can't have CSRF protection as requires session
+      csrf { disable() }
+      authorizeHttpRequests {
+        listOf(
+          "/health/**",
+          "/info",
+          "/v3/api-docs/**",
+          "/swagger-ui/**",
+          "/swagger-ui.html",
+          "/swagger-resources",
+          "/swagger-resources/configuration/ui",
+          "/swagger-resources/configuration/security",
+        ).forEach { authorize(it, permitAll) }
+        authorize(anyRequest, authenticated)
+      }
+      oauth2ResourceServer { jwt { jwtAuthenticationConverter = AuthAwareTokenConverter() } }
+    }
+    return http.build()
+  }
+
+  @Bean
+  fun locallyCachedJwtDecoder(
+    @Value("\${spring.security.oauth2.resourceserver.jwt.jwk-set-uri}") jwkSetUri: String,
+    cacheManager: CacheManager,
+  ): JwtDecoder = NimbusJwtDecoder.withJwkSetUri(jwkSetUri).cache(cacheManager.getCache("jwks")).build()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -4,11 +4,11 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors.PrisonerConvictionStatusChangeProcessor
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors.PrisonerConvictionStatusUpdatedProcessor
 
 @Service
 class DomainEventListenerService(
-  val prisonerConvictionStatusChangeProcessor: PrisonerConvictionStatusChangeProcessor,
+  val prisonerConvictionStatusUpdatedProcessor: PrisonerConvictionStatusUpdatedProcessor,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -19,7 +19,7 @@ class DomainEventListenerService(
     log.info("received event: {}", domainEvent)
 
     when (domainEvent.eventType) {
-      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> prisonerConvictionStatusChangeProcessor.processEvent(domainEvent)
+      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> prisonerConvictionStatusUpdatedProcessor.processEvent(domainEvent)
       else -> log.info("invalid message type: {}", domainEvent)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
+
+@Service
+class DomainEventListenerService {
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+    const val CONVICTION_STATUS_CHANGED_EVENT_TYPE = "prisoner-offender-search.prisoner.conviction-status.updated"
+  }
+
+  suspend fun handleMessage(domainEvent: DomainEvent) {
+    log.info("received event: {}", domainEvent)
+
+    when (domainEvent.eventType) {
+      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> log.info("received conviction status changed event: {}", domainEvent)
+      else -> log.info("invalid message type: {}", domainEvent)
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -12,14 +12,14 @@ class DomainEventListenerService(
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
-    const val CONVICTION_STATUS_CHANGED_EVENT_TYPE = "prisoner-offender-search.prisoner.conviction-status.updated"
+    const val CONVICTION_STATUS_UPDATED_EVENT_TYPE = "prisoner-offender-search.prisoner.conviction-status.updated"
   }
 
   suspend fun handleMessage(domainEvent: DomainEvent) {
     log.info("received event: {}", domainEvent)
 
     when (domainEvent.eventType) {
-      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> prisonerConvictionStatusUpdatedProcessor.processEvent(domainEvent)
+      CONVICTION_STATUS_UPDATED_EVENT_TYPE -> prisonerConvictionStatusUpdatedProcessor.processEvent(domainEvent)
       else -> log.info("invalid message type: {}", domainEvent)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -4,9 +4,12 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors.PrisonerConvictionStatusChangeProcessor
 
 @Service
-class DomainEventListenerService {
+class DomainEventListenerService(
+  val prisonerConvictionStatusChangeProcessor: PrisonerConvictionStatusChangeProcessor,
+) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
     const val CONVICTION_STATUS_CHANGED_EVENT_TYPE = "prisoner-offender-search.prisoner.conviction-status.updated"
@@ -16,7 +19,7 @@ class DomainEventListenerService {
     log.info("received event: {}", domainEvent)
 
     when (domainEvent.eventType) {
-      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> log.info("received conviction status changed event: {}", domainEvent)
+      CONVICTION_STATUS_CHANGED_EVENT_TYPE -> prisonerConvictionStatusChangeProcessor.processEvent(domainEvent)
       else -> log.info("invalid message type: {}", domainEvent)
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -18,7 +18,7 @@ class DomainEventListener(
   private val objectMapper: ObjectMapper,
 ) {
   companion object {
-    const val PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY = "prisonvisitsallocationalerts"
+    const val PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY = "prisonvisitsallocationevents"
   }
 
   @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.context.Context
+import io.opentelemetry.extension.kotlin.asContextElement
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.future.future
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.SQSMessage
+import java.util.concurrent.CompletableFuture
+
+@Service
+class DomainEventListener(
+  private val domainEventListenerService: DomainEventListenerService,
+  private val objectMapper: ObjectMapper,
+) {
+  companion object {
+    const val PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY = "prisonvisitsallocationalerts"
+  }
+
+  @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
+  fun processMessage(sqsMessage: SQSMessage): CompletableFuture<Void?> {
+    val event = objectMapper.readValue(sqsMessage.message, DomainEvent::class.java)
+    return CoroutineScope(Context.current().asContextElement()).future {
+      domainEventListenerService.handleMessage(event)
+      null
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/DomainEvent.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
+import jakarta.validation.constraints.NotBlank
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.deserializers.RawJsonDeserializer
+
+data class DomainEvent(
+  @NotBlank
+  val eventType: String,
+
+  @JsonDeserialize(using = RawJsonDeserializer::class)
+  @NotBlank
+  val additionalInformation: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/SQSMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/SQSMessage.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotBlank
+
+data class SQSMessage(
+  @NotBlank
+  @JsonProperty("Type")
+  val type: String,
+  @NotBlank
+  @JsonProperty("Message")
+  val message: String,
+  @JsonProperty("MessageId")
+  val messageId: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import jakarta.validation.constraints.NotBlank
+
+data class PrisonerConvictionStatusChangedInfo(
+  @NotBlank
+  @JsonProperty("nomsNumber")
+  val prisonerNumber: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/deserializers/RawJsonDeserializer.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/deserializers/RawJsonDeserializer.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.deserializers
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.JsonDeserializer
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import java.io.IOException
+
+class RawJsonDeserializer : JsonDeserializer<String>() {
+  @Throws(IOException::class, JsonProcessingException::class)
+  override fun deserialize(jp: JsonParser, ctxt: DeserializationContext): String {
+    val mapper = jp.codec as ObjectMapper
+    val node = mapper.readTree<JsonNode>(jp)
+    return mapper.writeValueAsString(node)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/processors/PrisonerConvictionStatusChangeProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/processors/PrisonerConvictionStatusChangeProcessor.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerConvictionStatusChangedInfo
+
+@Component
+class PrisonerConvictionStatusChangeProcessor(val objectMapper: ObjectMapper) {
+
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun processEvent(domainEvent: DomainEvent) {
+    LOG.info("received conviction status changed event: {}", domainEvent)
+    val additionalInfo = getAdditionalInfo(domainEvent)
+    // TODO: Call new allocation service - startAllocation method
+  }
+
+  private fun getAdditionalInfo(domainEvent: DomainEvent): PrisonerConvictionStatusChangedInfo {
+    return objectMapper.readValue(domainEvent.additionalInformation, PrisonerConvictionStatusChangedInfo::class.java)
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/processors/PrisonerConvictionStatusUpdatedProcessor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/processors/PrisonerConvictionStatusUpdatedProcessor.kt
@@ -8,7 +8,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.D
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerConvictionStatusChangedInfo
 
 @Component
-class PrisonerConvictionStatusChangeProcessor(val objectMapper: ObjectMapper) {
+class PrisonerConvictionStatusUpdatedProcessor(val objectMapper: ObjectMapper) {
 
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -17,7 +17,7 @@ hmpps:
     enabled: true
     provider: localstack
     queues:
-      prisonvisitsallocationalerts:
+      prisonvisitsallocationevents:
         queueName: sqs_hmpps_visits_allocation_events_queue
         dlqName: sqs_hmpps_visits_allocation_events_dlq
         subscribeTopicId: domainevents

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,3 +10,19 @@ spring:
 
 hmpps-auth:
   url: "https://sign-in-dev.hmpps.service.justice.gov.uk/auth"
+
+
+hmpps:
+  sqs:
+    enabled: true
+    provider: localstack
+    queues:
+      prisonvisitsallocationalerts:
+        queueName: sqs_hmpps_visits_allocation_events_queue
+        dlqName: sqs_hmpps_visits_allocation_events_dlq
+        subscribeTopicId: domainevents
+        dlqMaxReceiveCount: 1
+        visibilityTimeout: 1
+    topics:
+      domainevents:
+        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -78,3 +78,8 @@ management:
     info:
       cache:
         time-to-live: 2000ms
+
+hmpps:
+  sqs:
+    enabled: ${hmpps.sqs.enabled}
+    queueAdminRole: ROLE_VISIT_ALLOCATION_EVENTS_QUEUE_ADMIN

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/OpenApiDocsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/OpenApiDocsTest.kt
@@ -66,11 +66,17 @@ class OpenApiDocsTest : IntegrationTestBase() {
   fun `the open api json path security requirements are valid`() {
     val result = OpenAPIV3Parser().readLocation("http://localhost:$port/v3/api-docs", null, null)
 
-    // The security requirements of each path don't appear to be validated like they are at https://editor.swagger.io/
-    // We therefore need to grab all the valid security requirements and check that each path only contains those items
     val securityRequirements = result.openAPI.security.flatMap { it.keys }
     result.openAPI.paths.forEach { pathItem ->
-      assertThat(pathItem.value.get.security.flatMap { it.keys }).isSubsetOf(securityRequirements)
+      listOfNotNull(
+        pathItem.value.get,
+        pathItem.value.post,
+        pathItem.value.put,
+        pathItem.value.delete,
+      ).forEach { operation ->
+        val operationSecurity = operation.security?.flatMap { it.keys } ?: emptyList()
+        assertThat(operationSecurity).isSubsetOf(securityRequirements)
+      }
     }
   }
 
@@ -90,16 +96,5 @@ class OpenApiDocsTest : IntegrationTestBase() {
       }
       .jsonPath("$.components.securitySchemes.$key.bearerFormat").isEqualTo("JWT")
       .jsonPath("$.security[0].$key").isEqualTo(JSONArray().apply { this.add("read") })
-  }
-
-  @Test
-  fun `all endpoints have a security scheme defined`() {
-    webTestClient.get()
-      .uri("/v3/api-docs")
-      .accept(MediaType.APPLICATION_JSON)
-      .exchange()
-      .expectStatus().isOk
-      .expectBody()
-      .jsonPath("$.paths[*][*][?(!@.security)]").doesNotExist()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/ResourceSecurityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/ResourceSecurityTest.kt
@@ -31,6 +31,7 @@ class ResourceSecurityTest : IntegrationTestBase() {
     }.filterNotNull().flatMap { path -> listOf("GET", "POST", "PUT", "DELETE").map { "$it $path" } }
       .toMutableSet().also {
         it.addAll(unprotectedDefaultMethods)
+        it.addAll(listOf("PUT /queue-admin/retry-all-dlqs"))
       }
 
     val beans = context.getBeansOfType(RequestMappingHandlerMapping::class.java)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsIntegrationTestBase.kt
@@ -14,7 +14,7 @@ import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
 import uk.gov.justice.digital.hmpps.visitallocationapi.integration.domainevents.LocalStackContainer.setLocalStackProperties
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener.Companion.PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors.PrisonerConvictionStatusChangeProcessor
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.processors.PrisonerConvictionStatusUpdatedProcessor
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.HmppsTopic
@@ -55,7 +55,7 @@ abstract class EventsIntegrationTestBase {
   lateinit var domainEventListenerSpy: DomainEventListener
 
   @MockitoSpyBean
-  lateinit var prisonerConvictionStatusChangeProcessorSpy: PrisonerConvictionStatusChangeProcessor
+  lateinit var prisonerConvictionStatusUpdatedProcessorSpy: PrisonerConvictionStatusUpdatedProcessor
 
   @BeforeEach
   fun cleanQueue() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsIntegrationTestBase.kt
@@ -1,0 +1,80 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration.domainevents
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.domainevents.LocalStackContainer.setLocalStackProperties
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener.Companion.PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
+import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.HmppsTopic
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+abstract class EventsIntegrationTestBase {
+
+  companion object {
+    private val localStackContainer = LocalStackContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun testcontainers(registry: DynamicPropertyRegistry) {
+      localStackContainer?.also { setLocalStackProperties(it, registry) }
+    }
+  }
+
+  @Autowired
+  protected lateinit var objectMapper: ObjectMapper
+
+  @Autowired
+  private lateinit var hmppsQueueService: HmppsQueueService
+
+  internal val topic by lazy { hmppsQueueService.findByTopicId("domainevents") as HmppsTopic }
+
+  internal val prisonVisitsAllocationsQueue by lazy { hmppsQueueService.findByQueueId(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY) as HmppsQueue }
+
+  internal val sqsClient by lazy { prisonVisitsAllocationsQueue.sqsClient }
+  internal val sqsDlqClient by lazy { prisonVisitsAllocationsQueue.sqsDlqClient }
+  internal val queueUrl by lazy { prisonVisitsAllocationsQueue.queueUrl }
+  internal val dlqUrl by lazy { prisonVisitsAllocationsQueue.dlqUrl }
+
+  internal val awsSnsClient by lazy { topic.snsClient }
+  internal val topicArn by lazy { topic.arn }
+
+  @MockitoSpyBean
+  lateinit var domainEventListenerSpy: DomainEventListener
+
+  @BeforeEach
+  fun cleanQueue() {
+    purgeQueue(sqsClient, queueUrl)
+    purgeQueue(sqsDlqClient!!, dlqUrl!!)
+  }
+
+  fun purgeQueue(client: SqsAsyncClient, url: String) {
+    client.purgeQueue(PurgeQueueRequest.builder().queueUrl(url).build()).get()
+  }
+
+  fun createDomainEvent(eventType: String, additionalInformation: String = "test"): DomainEvent {
+    return DomainEvent(eventType = eventType, additionalInformation)
+  }
+
+  fun createDomainEventPublishRequest(eventType: String): PublishRequest? {
+    return PublishRequest.builder()
+      .topicArn(topicArn)
+      .message(objectMapper.writeValueAsString(createDomainEvent(eventType, ""))).build()
+  }
+
+  fun createDomainEventJson(eventType: String, additionalInformation: String): String {
+    return "{\"eventType\":\"$eventType\",\"additionalInformation\":$additionalInformation}"
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
@@ -28,6 +28,6 @@ class EventsSqsTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { sqsClient.countMessagesOnQueue(queueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
-    await untilAsserted { verify(prisonerConvictionStatusChangeProcessorSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(prisonerConvictionStatusUpdatedProcessorSpy, times(1)).processEvent(any()) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService.Companion.CONVICTION_STATUS_UPDATED_EVENT_TYPE
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 
 class EventsSqsTest : EventsIntegrationTestBase() {
@@ -28,6 +29,6 @@ class EventsSqsTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { sqsClient.countMessagesOnQueue(queueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
-    await untilAsserted { verify(prisonerConvictionStatusUpdatedProcessorSpy, times(1)).processEvent(any()) }
+    await untilAsserted { verify(prisonerConvictionStatusUpdatedProcessorSpy, times(1)).processEvent(objectMapper.readValue(domainEvent, DomainEvent::class.java)) }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
@@ -8,19 +8,19 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService.Companion.CONVICTION_STATUS_CHANGED_EVENT_TYPE
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService.Companion.CONVICTION_STATUS_UPDATED_EVENT_TYPE
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 
 class EventsSqsTest : EventsIntegrationTestBase() {
 
   @Test
-  fun `test prisoner-conviction-status-changed event is processed`() {
+  fun `test prisoner-conviction-status-updated event is processed`() {
     // Given
     val domainEvent = createDomainEventJson(
-      CONVICTION_STATUS_CHANGED_EVENT_TYPE,
+      CONVICTION_STATUS_UPDATED_EVENT_TYPE,
       createPrisonerConvictionStatusChangedAdditionalInformationJson("TEST"),
     )
-    val publishRequest = createDomainEventPublishRequest(CONVICTION_STATUS_CHANGED_EVENT_TYPE, domainEvent)
+    val publishRequest = createDomainEventPublishRequest(CONVICTION_STATUS_UPDATED_EVENT_TYPE, domainEvent)
 
     // When
     awsSnsClient.publish(publishRequest).get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/EventsSqsTest.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration.domainevents
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService.Companion.CONVICTION_STATUS_CHANGED_EVENT_TYPE
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+class EventsSqsTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `test sqs message is processed`() {
+    // Given
+    val publishRequest = createDomainEventPublishRequest(CONVICTION_STATUS_CHANGED_EVENT_TYPE)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilCallTo { sqsClient.countMessagesOnQueue(queueUrl).get() } matches { it == 0 }
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/LocalStackContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/domainevents/LocalStackContainer.kt
@@ -1,0 +1,45 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration.domainevents
+
+import org.slf4j.LoggerFactory
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.testcontainers.containers.localstack.LocalStackContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.utility.DockerImageName
+import java.io.IOException
+import java.net.ServerSocket
+
+object LocalStackContainer {
+  val log = LoggerFactory.getLogger(this::class.java)
+  val instance by lazy { startLocalstackIfNotRunning() }
+
+  fun setLocalStackProperties(localStackContainer: LocalStackContainer, registry: DynamicPropertyRegistry) {
+    registry.add("hmpps.sqs.localstackUrl") { localStackContainer.getEndpointOverride(LocalStackContainer.Service.SNS) }
+    registry.add("hmpps.sqs.region") { localStackContainer.region }
+  }
+
+  private fun startLocalstackIfNotRunning(): LocalStackContainer? {
+    if (localstackIsRunning()) return null
+    val logConsumer = Slf4jLogConsumer(log).withPrefix("localstack")
+    return LocalStackContainer(
+      DockerImageName.parse("localstack/localstack").withTag("1.3"),
+    ).apply {
+      withServices(LocalStackContainer.Service.SNS, LocalStackContainer.Service.SQS)
+      withEnv("HOSTNAME_EXTERNAL", "localhost")
+      withEnv("DEFAULT_REGION", "eu-west-2")
+      waitingFor(
+        Wait.forLogMessage(".*Ready.*", 1),
+      )
+      start()
+      followOutput(logConsumer)
+    }
+  }
+
+  private fun localstackIsRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(4566)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -25,7 +25,7 @@ hmpps:
     enabled: true
     provider: localstack
     queues:
-      prisonvisitsallocationalerts:
+      prisonvisitsallocationevents:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}
         subscribeTopicId: domainevents

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,7 +18,22 @@ spring:
 
 
 hmpps-auth:
-  url: "http://localhost:8090/auth"
+    url: "http://localhost:8090/auth"
+
+hmpps:
+  sqs:
+    enabled: true
+    provider: localstack
+    queues:
+      prisonvisitsallocationalerts:
+        queueName: ${random.uuid}
+        dlqName: ${random.uuid}
+        subscribeTopicId: domainevents
+        dlqMaxReceiveCount: 1
+        visibilityTimeout: 1
+    topics:
+      domainevents:
+        arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}
 
 # example client configuration for calling out to other services
 # TODO: Remove / replace this configuration


### PR DESCRIPTION
## What does this PR do?
Add the ability for the visit-allocation-api to listen to the prison visits events SNS topic on a new SQS queue. Add processor to consume the message from the queue and transform it into a class.

Add TODO comment to remember to hook up the call to new allocation service (next change in this feature).

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5084