### PR TITLE
Fix SQS deployment issues

### DIFF
--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -1,5 +1,6 @@
 generic-service:
   nameOverride: hmpps-visit-allocation-api
+  serviceAccountName: visit-someone-in-prison
   productId: "DPS035"
 
   replicaCount: 4

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -13,14 +12,12 @@ import java.util.function.Supplier
 class VisitAllocationEventJobSqsService(
   private val hmppsQueueService: HmppsQueueService,
   private val objectMapper: ObjectMapper,
-  @Value("\${hmpps.sqs.queues.visitsallocationeventjob.queue-name}")
-  private val queueName: String,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  private val visitsAllocationEventJobQueue by lazy { hmppsQueueService.findByQueueName(queueName) ?: throw RuntimeException("Queue with name $queueName doesn't exist") }
+  private val visitsAllocationEventJobQueue by lazy { hmppsQueueService.findByQueueId("visitsallocationeventjob") ?: throw RuntimeException("Queue with name visitsallocationeventjob doesn't exist") }
   private val visitsAllocationEventJobSqsClient by lazy { visitsAllocationEventJobQueue.sqsClient }
   private val visitsAllocationEventJobQueueUrl by lazy { visitsAllocationEventJobQueue.queueUrl }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
@@ -13,7 +13,7 @@ import java.util.function.Supplier
 class VisitAllocationEventJobSqsService(
   private val hmppsQueueService: HmppsQueueService,
   private val objectMapper: ObjectMapper,
-  @Value("\${hmpps.sqs.queues.visitsallocationeventjob.queueName}")
+  @Value("\${hmpps.sqs.queues.visitsallocationeventjob.queue-name}")
   private val queueName: String,
 ) {
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
@@ -3,7 +3,6 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
@@ -12,14 +11,12 @@ import uk.gov.justice.hmpps.sqs.HmppsQueueService
 class VisitAllocationPrisonerRetrySqsService(
   private val hmppsQueueService: HmppsQueueService,
   private val objectMapper: ObjectMapper,
-  @Value("\${hmpps.sqs.queues.prisonvisitsallocationprisonerretryqueue.queue-name}")
-  private val queueName: String,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  private val visitAllocationPrisonerRetryQueue by lazy { hmppsQueueService.findByQueueName(queueName) ?: throw RuntimeException("Queue with name $queueName doesn't exist") }
+  private val visitAllocationPrisonerRetryQueue by lazy { hmppsQueueService.findByQueueId("prisonvisitsallocationprisonerretryqueue") ?: throw RuntimeException("Queue with name prisonvisitsallocationprisonerretryqueue doesn't exist") }
   private val visitAllocationPrisonerRetrySqsClient by lazy { visitAllocationPrisonerRetryQueue.sqsClient }
   private val visitAllocationPrisonerRetryQueueUrl by lazy { visitAllocationPrisonerRetryQueue.queueUrl }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.hmpps.sqs.HmppsQueueService
 class VisitAllocationPrisonerRetrySqsService(
   private val hmppsQueueService: HmppsQueueService,
   private val objectMapper: ObjectMapper,
-  @Value("\${hmpps.sqs.queues.prisonvisitsallocationprisonerretryqueue.queueName}")
+  @Value("\${hmpps.sqs.queues.prisonvisitsallocationprisonerretryqueue.queue-name}")
   private val queueName: String,
 ) {
   companion object {


### PR DESCRIPTION
## Issue
Our visit-allocation-api wasn't deploying to dev. It was failing due to multiple reasons.
1. The SQS queue name wasn't loading in correctly.
2. The IRSA policies were missing from cloud-platform-environments, which meant we were getting AWS auth errors.

## Fix
1. To fix this, we used findQueueById instead of by name.
2. We had to add the policies and add a custom service-account to the values.yaml file in helm_deploy.