### PR TITLE
Increase pool size and connection timeouts to help with high db loads

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
     hikari:
       pool-name: VisitAllocation-CP
       maximum-pool-size: 20
-      connection-timeout: 30000
+      connection-timeout: 10000
       validation-timeout: 5000
 
 server:


### PR DESCRIPTION
## What does this PR do?
during migration, we'll be hitting the service a lot in a small space of time. Increase the pool / connection timeouts to help with this.