### PR TITLE
VB-5298 - Make lastVoAllocationDate optional

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
@@ -20,5 +20,5 @@ data class VisitAllocationPrisonerMigrationDto(
   val pvoBalance: Int,
 
   @Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = false)
-  var lastVoAllocationDate: LocalDate? = LocalDate.now().minusDays(28)
+  var lastVoAllocationDate: LocalDate? = LocalDate.now().minusDays(28),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
@@ -19,7 +19,6 @@ data class VisitAllocationPrisonerMigrationDto(
   @field:NotNull
   val pvoBalance: Int,
 
-  @Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = true)
-  @field:NotNull
-  val lastVoAllocationDate: LocalDate,
+  @Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = false)
+  var lastVoAllocationDate: LocalDate? = LocalDate.now().minusDays(28)
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
@@ -20,5 +20,5 @@ data class VisitAllocationPrisonerMigrationDto(
   val pvoBalance: Int,
 
   @Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = false)
-  var lastVoAllocationDate: LocalDate? = LocalDate.now().minusDays(28),
+  var lastVoAllocationDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -28,6 +28,7 @@ class NomisMigrationService(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+    const val NULL_LAST_ALLOCATION_DATE_OFFSET = 28L
   }
 
   @Transactional
@@ -37,7 +38,7 @@ class NomisMigrationService(
     // Due to bad data in NOMIS, it's possible for a prisoner to exist with a balance but no IEP date.
     // When this happens, set it to TODAY - 28 DAYS. This allows prisoner to receive IEP allocation ASAP.
     if (migrationDto.lastVoAllocationDate == null) {
-      migrationDto.lastVoAllocationDate = LocalDate.now().minusDays(28)
+      migrationDto.lastVoAllocationDate = LocalDate.now().minusDays(NULL_LAST_ALLOCATION_DATE_OFFSET)
     }
 
     migrateBalance(migrationDto, VisitOrderType.VO)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepository
+import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.abs
 
@@ -32,6 +33,12 @@ class NomisMigrationService(
   @Transactional
   fun migratePrisoner(migrationDto: VisitAllocationPrisonerMigrationDto) {
     LOG.info("Entered NomisMigrationService - migratePrisoner with migration dto {}", migrationDto)
+
+    // Due to bad data in NOMIS, it's possible for a prisoner to exist with a balance but no IEP date.
+    // When this happens, set it to TODAY - 28 DAYS. This allows prisoner to receive IEP allocation ASAP.
+    if (migrationDto.lastVoAllocationDate == null) {
+      migrationDto.lastVoAllocationDate = LocalDate.now().minusDays(28)
+    }
 
     migrateBalance(migrationDto, VisitOrderType.VO)
     migrateBalance(migrationDto, VisitOrderType.PVO)
@@ -73,7 +80,7 @@ class NomisMigrationService(
         prisonerId = migrationDto.prisonerId,
         type = type,
         status = VisitOrderStatus.AVAILABLE,
-        createdTimestamp = migrationDto.lastVoAllocationDate.atStartOfDay(),
+        createdTimestamp = migrationDto.lastVoAllocationDate!!.atStartOfDay(),
         expiryDate = null,
       )
     }
@@ -110,6 +117,6 @@ class NomisMigrationService(
       null
     }
 
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = migrationDto.prisonerId, lastVoAllocatedDate = migrationDto.lastVoAllocationDate, lastPvoAllocatedDate = lastPvoAllocatedDate))
+    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = migrationDto.prisonerId, lastVoAllocatedDate = migrationDto.lastVoAllocationDate!!, lastPvoAllocatedDate = lastPvoAllocatedDate))
   }
 }


### PR DESCRIPTION
## What does this PR do?
Some prisoners on NOMIS have a balance but don't have an IEP allocation date. This change allows those prisoners to be migrated.

If a null date is found, we set it to TODAY - 28 DAYS, to get as close to next IEP allocation date as possible for prisoner.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5298