### PR TITLE
Update sync endpoint to allow vo and pvo balances to be nullable

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/VisitAllocationApiExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/VisitAllocationApiExceptionHandler.kt
@@ -12,6 +12,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.servlet.resource.NoResourceFoundException
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.InvalidSyncRequestException
 import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
@@ -31,6 +32,17 @@ class VisitAllocationApiExceptionHandler {
         developerMessage = e.message,
       ),
     ).also { log.info("Validation exception: {}", e.message) }
+
+  @ExceptionHandler(InvalidSyncRequestException::class)
+  fun handleInvalidSyncRequestException(e: InvalidSyncRequestException): ResponseEntity<ErrorResponse> = ResponseEntity
+    .status(BAD_REQUEST)
+    .body(
+      ErrorResponse(
+        status = BAD_REQUEST,
+        userMessage = "${e.message}",
+        developerMessage = e.message,
+      ),
+    )
 
   @ExceptionHandler(MethodArgumentNotValidException::class)
   fun handleMethodArgumentException(e: MethodArgumentNotValidException): ResponseEntity<ErrorResponse> = ResponseEntity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
@@ -14,15 +14,13 @@ data class VisitAllocationPrisonerSyncDto(
   val prisonerId: String,
 
   @Schema(description = "The previous VO balance (can be negative)", example = "5", required = true)
-  @field:NotNull
-  val oldVoBalance: Int,
+  val oldVoBalance: Int? = null,
 
   @Schema(description = "The change of the VO balance (can be negative)", example = "5", required = false)
   val changeToVoBalance: Int? = null,
 
   @Schema(description = "The previous PVO balance (can be negative)", example = "2", required = true)
-  @field:NotNull
-  val oldPvoBalance: Int,
+  val oldPvoBalance: Int? = null,
 
   @Schema(description = "The change of the PVO balance (can be negative)", example = "5", required = false)
   val changeToPvoBalance: Int? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
@@ -13,13 +13,13 @@ data class VisitAllocationPrisonerSyncDto(
   @field:NotEmpty
   val prisonerId: String,
 
-  @Schema(description = "The previous VO balance (can be negative)", example = "5", required = true)
+  @Schema(description = "The previous VO balance (can be negative)", example = "5", required = false)
   val oldVoBalance: Int? = null,
 
   @Schema(description = "The change of the VO balance (can be negative)", example = "5", required = false)
   val changeToVoBalance: Int? = null,
 
-  @Schema(description = "The previous PVO balance (can be negative)", example = "2", required = true)
+  @Schema(description = "The previous PVO balance (can be negative)", example = "2", required = false)
   val oldPvoBalance: Int? = null,
 
   @Schema(description = "The change of the PVO balance (can be negative)", example = "5", required = false)
@@ -37,6 +37,6 @@ data class VisitAllocationPrisonerSyncDto(
   @field:NotNull
   val changeLogSource: ChangeLogSource,
 
-  @Schema(description = "Additional information on the sync reason", example = "Manually adjusted for phone credit", required = true)
+  @Schema(description = "Additional information on the sync reason", example = "Manually adjusted for phone credit", required = false)
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/exception/InvalidSyncRequestException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/exception/InvalidSyncRequestException.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.exception
+
+import jakarta.validation.ValidationException
+import java.util.function.Supplier
+
+class InvalidSyncRequestException(message: String? = null, cause: Throwable? = null) :
+  ValidationException(message, cause),
+  Supplier<InvalidSyncRequestException> {
+  override fun get(): InvalidSyncRequestException = InvalidSyncRequestException(message, cause)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -47,12 +47,30 @@ class NomisSyncService(
     }
 
     // If VO balance has changed, sync it
-    val wantedVoChange = calculateAmountToChange(prisonerBalance.voBalance, syncDto.oldVoBalance, syncDto.changeToVoBalance ?: 0)
-    processSync(syncDto.prisonerId, prisonerBalance.voBalance, wantedVoChange, VisitOrderType.VO, NegativeVisitOrderType.NEGATIVE_VO)
+    if (syncDto.oldVoBalance != null) {
+      val wantedVoChange = calculateAmountToChange(prisonerBalance.voBalance, syncDto.oldVoBalance, syncDto.changeToVoBalance ?: 0)
+
+      processSync(
+        syncDto.prisonerId,
+        prisonerBalance.voBalance,
+        wantedVoChange,
+        VisitOrderType.VO,
+        NegativeVisitOrderType.NEGATIVE_VO,
+      )
+    }
 
     // If PVO balance has changed, sync it
-    val wantedPvoChange = calculateAmountToChange(prisonerBalance.pvoBalance, syncDto.oldPvoBalance, syncDto.changeToPvoBalance ?: 0)
-    processSync(syncDto.prisonerId, prisonerBalance.pvoBalance, wantedPvoChange, VisitOrderType.PVO, NegativeVisitOrderType.NEGATIVE_PVO)
+    if (syncDto.oldPvoBalance != null) {
+      val wantedPvoChange = calculateAmountToChange(prisonerBalance.pvoBalance, syncDto.oldPvoBalance, syncDto.changeToPvoBalance ?: 0)
+
+      processSync(
+        syncDto.prisonerId,
+        prisonerBalance.pvoBalance,
+        wantedPvoChange,
+        VisitOrderType.PVO,
+        NegativeVisitOrderType.NEGATIVE_PVO,
+      )
+    }
 
     // If this is a VO allocation from the NOMIS system, update the lastVoAllocatedDate to keep this synced.
     if (syncDto.adjustmentReasonCode == AdjustmentReasonCode.IEP && syncDto.changeLogSource == ChangeLogSource.SYSTEM) {
@@ -154,16 +172,28 @@ class NomisSyncService(
   }
 
   private fun compareBalanceBeforeSync(syncDto: VisitAllocationPrisonerSyncDto, prisonerBalance: PrisonerBalanceDto) {
-    if (prisonerBalance.voBalance != syncDto.oldVoBalance || prisonerBalance.pvoBalance != syncDto.oldPvoBalance) {
-      LOG.error("Discovered discrepancy between NOMIS and DPS balances. Logging error to application insights for prisoner ${syncDto.prisonerId}")
-      val telemetryBalanceProperties = mapOf(
-        "prisonerId" to syncDto.prisonerId,
-        "nomisVoBalance" to syncDto.oldVoBalance.toString(),
-        "nomisPvoBalance" to syncDto.oldPvoBalance.toString(),
-        "dpsVoBalance" to prisonerBalance.voBalance.toString(),
-        "dpsPvoBalance" to prisonerBalance.pvoBalance.toString(),
-      )
-      telemetryService.trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryBalanceProperties)
+    if (syncDto.oldVoBalance != null) {
+      if (prisonerBalance.voBalance != syncDto.oldVoBalance) {
+        LOG.error("Discovered discrepancy between NOMIS and DPS VO balances. Logging error to application insights for prisoner ${syncDto.prisonerId}")
+        val telemetryBalanceProperties = mapOf(
+          "prisonerId" to syncDto.prisonerId,
+          "nomisVoBalance" to syncDto.oldVoBalance.toString(),
+          "dpsVoBalance" to prisonerBalance.voBalance.toString(),
+        )
+        telemetryService.trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryBalanceProperties)
+      }
+    }
+
+    if (syncDto.oldPvoBalance != null) {
+      if (prisonerBalance.pvoBalance != syncDto.oldPvoBalance) {
+        LOG.error("Discovered discrepancy between NOMIS and DPS PVO balances. Logging error to application insights for prisoner ${syncDto.prisonerId}")
+        val telemetryBalanceProperties = mapOf(
+          "prisonerId" to syncDto.prisonerId,
+          "nomisPvoBalance" to syncDto.oldPvoBalance.toString(),
+          "dpsPvoBalance" to prisonerBalance.pvoBalance.toString(),
+        )
+        telemetryService.trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryBalanceProperties)
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -353,14 +353,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -394,14 +399,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -435,14 +445,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -476,14 +491,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -518,14 +538,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -561,14 +586,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -603,14 +633,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   /**
@@ -646,14 +681,19 @@ class NomisSyncServiceTest {
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
-    val telemetryProperties = createTelemetrySyncProperties(
+    val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
       syncDto.oldVoBalance.toString(),
-      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.voBalance.toString(),
+    )
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, voTelemetryProperties)
+
+    val pvoTelemetryProperties = createTelemetryPvoSyncProperties(
+      prisonerId,
+      syncDto.oldPvoBalance.toString(),
       existingPrisonerBalance.pvoBalance.toString(),
     )
-    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, telemetryProperties)
+    verify(telemetryClientService, times(1)).trackEvent(TelemetryEventType.BALANCES_OUT_OF_SYNC, pvoTelemetryProperties)
   }
 
   private fun createSyncRequest(
@@ -678,11 +718,15 @@ class NomisSyncServiceTest {
     comment,
   )
 
-  private fun createTelemetrySyncProperties(prisonerId: String, nomisVoBalance: String, nomisPvoBalance: String, dpsVoBalance: String, dpsPvoBalance: String): Map<String, String> = mapOf(
+  private fun createTelemetryVoSyncProperties(prisonerId: String, nomisVoBalance: String, dpsVoBalance: String): Map<String, String> = mapOf(
     "prisonerId" to prisonerId,
     "nomisVoBalance" to nomisVoBalance,
-    "nomisPvoBalance" to nomisPvoBalance,
     "dpsVoBalance" to dpsVoBalance,
+  )
+
+  private fun createTelemetryPvoSyncProperties(prisonerId: String, nomisPvoBalance: String, dpsPvoBalance: String): Map<String, String> = mapOf(
+    "prisonerId" to prisonerId,
+    "nomisPvoBalance" to nomisPvoBalance,
     "dpsPvoBalance" to dpsPvoBalance,
   )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
@@ -353,6 +353,42 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   }
 
   @Test
+  fun `when changeToVoBalance is given but oldVoBalance is null, return a 400 Bad Request`() {
+    // Given
+    val prisonerSyncDto = createSyncRequest(
+      prisonerId = PRISONER_ID,
+      oldVoBalance = null,
+      changeToVoBalance = 1,
+      oldPvoBalance = 2,
+      changeToPvoBalance = 1,
+    )
+
+    // When
+    val responseSpec = callVisitAllocationSyncEndpoint(webTestClient, prisonerSyncDto, setAuthorisation(roles = listOf("ROLE_VISIT_ALLOCATION_API__NOMIS_API")))
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `when changeToPvoBalance is given but oldPvoBalance is null, return a 400 Bad Request`() {
+    // Given
+    val prisonerSyncDto = createSyncRequest(
+      prisonerId = PRISONER_ID,
+      oldVoBalance = 2,
+      changeToVoBalance = 1,
+      oldPvoBalance = null,
+      changeToPvoBalance = 1,
+    )
+
+    // When
+    val responseSpec = callVisitAllocationSyncEndpoint(webTestClient, prisonerSyncDto, setAuthorisation(roles = listOf("ROLE_VISIT_ALLOCATION_API__NOMIS_API")))
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
   fun `when request body validation fails then 400 bad request is returned`() {
     // Given
     val prisonerSyncDto = VisitAllocationPrisonerSyncDto("", 5, 1, 2, 0, LocalDate.now().minusDays(1), AdjustmentReasonCode.VO_ISSUE, ChangeLogSource.SYSTEM, "issued vo")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
@@ -166,7 +166,7 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 6, expectedPvoCount = 3, expectedNegativeVoCount = 0, expectedNegativePvoCount = 0)
-    verify(telemetryClientService, times(1)).trackEvent(any(), any())
+    verify(telemetryClientService, times(2)).trackEvent(any(), any())
   }
 
   /**
@@ -193,7 +193,7 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 6, expectedPvoCount = 3, expectedNegativeVoCount = 0, expectedNegativePvoCount = 0)
-    verify(telemetryClientService, times(1)).trackEvent(any(), any())
+    verify(telemetryClientService, times(2)).trackEvent(any(), any())
   }
 
   /**
@@ -267,7 +267,7 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 0, expectedPvoCount = 0, expectedNegativeVoCount = 2, expectedNegativePvoCount = 2)
-    verify(telemetryClientService, times(1)).trackEvent(any(), any())
+    verify(telemetryClientService, times(2)).trackEvent(any(), any())
   }
 
   /**
@@ -295,7 +295,61 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
     assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 1, expectedPvoCount = 1, expectedNegativeVoCount = 0, expectedNegativePvoCount = 0)
-    verify(telemetryClientService, times(1)).trackEvent(any(), any())
+    verify(telemetryClientService, times(2)).trackEvent(any(), any())
+  }
+
+  /**
+   * Scenario 11: Existing Prisoner with no change to VO balance, then VO processing is skipped.
+   */
+  @Test
+  fun `when an existing prisoner with only a PVO balance change, then VO processing is skipped`() {
+    // Given
+    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
+    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
+    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    val prisonerSyncDto = createSyncRequest(
+      prisonerId = PRISONER_ID,
+      oldVoBalance = null,
+      changeToVoBalance = null,
+      oldPvoBalance = 2,
+      changeToPvoBalance = 1,
+    )
+
+    // When
+    val responseSpec = callVisitAllocationSyncEndpoint(webTestClient, prisonerSyncDto, setAuthorisation(roles = listOf("ROLE_VISIT_ALLOCATION_API__NOMIS_API")))
+
+    // Then
+    responseSpec.expectStatus().isOk
+    assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 5, expectedPvoCount = 3, expectedNegativeVoCount = 0, expectedNegativePvoCount = 0)
+    verifyNoInteractions(telemetryClientService)
+  }
+
+  /**
+   * Scenario 12: Existing Prisoner with no change to PVO balance, then PVO processing is skipped.
+   */
+  @Test
+  fun `when an existing prisoner with only a VO balance change, then PVO processing is skipped`() {
+    // Given
+    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
+    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
+    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    val prisonerSyncDto = createSyncRequest(
+      prisonerId = PRISONER_ID,
+      oldVoBalance = 5,
+      changeToVoBalance = 1,
+      oldPvoBalance = null,
+      changeToPvoBalance = null,
+    )
+
+    // When
+    val responseSpec = callVisitAllocationSyncEndpoint(webTestClient, prisonerSyncDto, setAuthorisation(roles = listOf("ROLE_VISIT_ALLOCATION_API__NOMIS_API")))
+
+    // Then
+    responseSpec.expectStatus().isOk
+    assertSyncResults(prisonerSyncDto = prisonerSyncDto, expectedVoCount = 6, expectedPvoCount = 2, expectedNegativeVoCount = 0, expectedNegativePvoCount = 0)
+    verifyNoInteractions(telemetryClientService)
   }
 
   @Test
@@ -347,9 +401,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
 
   private fun createSyncRequest(
     prisonerId: String,
-    oldVoBalance: Int,
+    oldVoBalance: Int? = null,
     changeToVoBalance: Int? = null,
-    oldPvoBalance: Int,
+    oldPvoBalance: Int? = null,
     changeToPvoBalance: Int? = null,
     createdDate: LocalDate = LocalDate.now(),
     adjustmentReasonCode: AdjustmentReasonCode = AdjustmentReasonCode.IEP,


### PR DESCRIPTION
## What does this PR do?
When a sync request comes in, sometimes it's only for a VO or only for a PVO. We are updating our code to account for this. Now we will only process VOs if oldVoBalance is present and PVOs if oldPvoBalance is present.