### PR TITLE
VB-5297 - Allocation handles prisoners with negative balances

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.projections.NegativePrisonerBalance
@@ -21,6 +22,15 @@ interface NegativeVisitOrderRepository : JpaRepository<NegativeVisitOrder, Long>
   fun getPrisonerNegativeBalance(
     prisonerId: String,
   ): List<NegativePrisonerBalance>
+
+  @Query(
+    "SELECT COUNT(nvo) FROM NegativeVisitOrder nvo WHERE nvo.prisonerId = :prisonerId AND nvo.type = :type AND nvo.status = :status",
+  )
+  fun countAllNegativeVisitOrders(
+    prisonerId: String,
+    type: NegativeVisitOrderType,
+    status: NegativeVisitOrderStatus,
+  ): Int
 
   @Transactional
   @Modifying
@@ -40,7 +50,7 @@ interface NegativeVisitOrderRepository : JpaRepository<NegativeVisitOrder, Long>
     """,
     nativeQuery = true,
   )
-  fun repayVisitOrdersGivenAmount(
+  fun repayNegativeVisitOrdersGivenAmount(
     prisonerId: String,
     negativeVisitOrderType: NegativeVisitOrderType,
     amountToExpire: Long?,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -102,11 +102,11 @@ class NomisSyncService(
     } else {
       if ((prisonerDpsBalance + balanceChange) <= 0) {
         LOG.info("Balance increased but remains negative for prisoner $prisonerId, repaying $balanceChange, $negativeVoType")
-        negativeVisitOrderRepository.repayVisitOrdersGivenAmount(prisonerId, negativeVoType, abs(balanceChange).toLong())
+        negativeVisitOrderRepository.repayNegativeVisitOrdersGivenAmount(prisonerId, negativeVoType, abs(balanceChange).toLong())
       } else {
         val positiveVosToCreate = prisonerDpsBalance + balanceChange
         LOG.info("Balance increased and is positive for prisoner $prisonerId, repaying all $negativeVoType and creating $positiveVosToCreate $visitOrderType")
-        negativeVisitOrderRepository.repayVisitOrdersGivenAmount(prisonerId, negativeVoType, null)
+        negativeVisitOrderRepository.repayNegativeVisitOrdersGivenAmount(prisonerId, negativeVoType, null)
         createAndSaveVisitOrders(prisonerId, visitOrderType, positiveVosToCreate)
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/AllocationServiceTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.visitallocationapi.integration.allocations
+package uk.gov.justice.digital.hmpps.visitallocationapi
 
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.BeforeEach
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderAllocationPrisonJobRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.AllocationService
@@ -49,11 +50,23 @@ class AllocationServiceTest {
   @Mock
   private lateinit var prisonerRetryService: PrisonerRetryService
 
+  @Mock
+  private lateinit var negativeVisitOrderRepository: NegativeVisitOrderRepository
+
   private lateinit var allocationService: AllocationService
 
   @BeforeEach
   fun setUp() {
-    allocationService = AllocationService(prisonerSearchClient, incentivesClient, visitOrderRepository, visitOrderAllocationPrisonJobRepository, prisonerDetailsService, prisonerRetryService, 26)
+    allocationService = AllocationService(
+      prisonerSearchClient,
+      incentivesClient,
+      visitOrderRepository,
+      visitOrderAllocationPrisonJobRepository,
+      prisonerDetailsService,
+      prisonerRetryService,
+      negativeVisitOrderRepository,
+      26,
+    )
   }
 
   // --- Start Allocation Tests --- \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -199,8 +199,8 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisoner(syncDto)
 
     // THEN
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, 1)
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, 1)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, 1)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, 1)
 
     verify(changeLogService, times(1)).logSyncChange(syncDto)
 
@@ -225,8 +225,8 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisoner(syncDto)
 
     // THEN
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, null)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, null)
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
 
     val visitOrdersSaved = visitOrderCaptor.allValues[0]
@@ -480,7 +480,7 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisoner(syncDto)
 
     // THEN - Capture the visit orders that were saved
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
 
     // Retrieve the captured values
@@ -520,8 +520,8 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisoner(syncDto)
 
     // THEN - Capture the visit orders that were saved
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
-    verify(negativeVisitOrderRepository, times(1)).repayVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, null)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
+    verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, null)
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
 
     // Retrieve the captured values

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
@@ -20,9 +20,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.AdjustmentReasonCode
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper.callPost
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import java.time.LocalDate
 
 @DisplayName("NomisController sync tests - $VO_PRISONER_SYNC")
@@ -38,8 +36,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a positive balance increases, then DPS service successfully syncs`() {
     // Given
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -65,8 +63,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a negative balance decreases, then DPS service successfully syncs`() {
     // Given
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 5)
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 2)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 5)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 2)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -93,8 +91,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a positive balance decreases below zero, then DPS service successfully syncs`() {
     // Given
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -121,8 +119,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a negative balance increases above zero, then DPS service successfully syncs`() {
     // Given
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 2)
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 1)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 2)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 1)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -148,8 +146,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with an out of sync (DPS higher) positive balance increases, then DPS service successfully syncs`() {
     // Given
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 6)
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 3)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 6)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 3)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -175,8 +173,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with an out of sync (NOMIS higher) positive balance increases, then DPS service successfully syncs`() {
     // Given
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 4)
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 4)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -249,8 +247,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with an out of sync (DPS higher) and a positive balance decreases below zero, then DPS service successfully syncs`() {
     // Given
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
-    createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -277,8 +275,8 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with an out of sync (NOMIS higher) and a negative balance increases above zero, then DPS service successfully syncs`() {
     // Given
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 1)
-    createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 1)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_VO, 1)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, NegativeVisitOrderType.NEGATIVE_PVO, 1)
     prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
 
     val prisonerSyncDto = createSyncRequest(
@@ -366,34 +364,6 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     changeLogSource,
     comment,
   )
-
-  private fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, amountToCreate: Int) {
-    val visitOrders = mutableListOf<VisitOrder>()
-    repeat(amountToCreate) {
-      visitOrders.add(
-        VisitOrder(
-          prisonerId = prisonerId,
-          type = visitOrderType,
-          status = VisitOrderStatus.AVAILABLE,
-        ),
-      )
-    }
-    visitOrderRepository.saveAll(visitOrders)
-  }
-
-  private fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: NegativeVisitOrderType, amountToCreate: Int) {
-    val negativeVisitOrders = mutableListOf<NegativeVisitOrder>()
-    repeat(amountToCreate) {
-      negativeVisitOrders.add(
-        NegativeVisitOrder(
-          prisonerId = prisonerId,
-          type = negativeVoType,
-          status = NegativeVisitOrderStatus.USED,
-        ),
-      )
-    }
-    negativeVisitOrderRepository.saveAll(negativeVisitOrders)
-  }
 
   private fun assertSyncResults(prisonerSyncDto: VisitAllocationPrisonerSyncDto, expectedVoCount: Int, expectedPvoCount: Int, expectedNegativeVoCount: Int, expectedNegativePvoCount: Int) {
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -5,8 +5,6 @@ import org.awaitility.kotlin.await
 import org.awaitility.kotlin.matches
 import org.awaitility.kotlin.untilAsserted
 import org.awaitility.kotlin.untilCallTo
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
@@ -27,20 +25,6 @@ import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
   @MockitoSpyBean
   lateinit var visitAllocationPrisonerRetryQueueListenerSpy: VisitAllocationPrisonerRetryQueueListener
-
-  @BeforeEach
-  fun setup() {
-    visitOrderAllocationPrisonJobRepository.deleteAll()
-    visitOrderRepository.deleteAll()
-    prisonerDetailsRepository.deleteAll()
-  }
-
-  @AfterEach
-  fun cleanup() {
-    visitOrderAllocationPrisonJobRepository.deleteAll()
-    visitOrderRepository.deleteAll()
-    prisonerDetailsRepository.deleteAll()
-  }
 
   @Test
   fun `when prisoner put on retry queue the message is processed`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
@@ -2,6 +2,12 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper
 
 import org.springframework.stereotype.Component
 import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderPrison
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
@@ -22,6 +28,36 @@ class EntityHelper(
   @Transactional
   fun savePrison(visitOrderPrison: VisitOrderPrison) {
     visitOrderPrisonRepository.saveAndFlush(visitOrderPrison)
+  }
+
+  @Transactional
+  fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, amountToCreate: Int) {
+    val visitOrders = mutableListOf<VisitOrder>()
+    repeat(amountToCreate) {
+      visitOrders.add(
+        VisitOrder(
+          prisonerId = prisonerId,
+          type = visitOrderType,
+          status = VisitOrderStatus.AVAILABLE,
+        ),
+      )
+    }
+    visitOrderRepository.saveAll(visitOrders)
+  }
+
+  @Transactional
+  fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: NegativeVisitOrderType, amountToCreate: Int) {
+    val negativeVisitOrders = mutableListOf<NegativeVisitOrder>()
+    repeat(amountToCreate) {
+      negativeVisitOrders.add(
+        NegativeVisitOrder(
+          prisonerId = prisonerId,
+          type = negativeVoType,
+          status = NegativeVisitOrderStatus.USED,
+        ),
+      )
+    }
+    negativeVisitOrderRepository.saveAll(negativeVisitOrders)
   }
 
   @Transactional


### PR DESCRIPTION
## What does this PR do?
When a balance of a prisoner is negative, first repay the prisoners balance before generating new allocation.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5297