### PR TITLE
Fix - Migration needs to reset a prisoner if they exist

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
@@ -55,4 +55,8 @@ interface NegativeVisitOrderRepository : JpaRepository<NegativeVisitOrder, Long>
     negativeVisitOrderType: NegativeVisitOrderType,
     amountToExpire: Long?,
   ): Int
+
+  @Transactional
+  @Modifying
+  fun deleteAllByPrisonerId(prisonerId: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -14,6 +14,10 @@ interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, Long> {
 
   @Transactional
   @Modifying
+  fun deleteByPrisonerId(prisonerId: String)
+
+  @Transactional
+  @Modifying
   @Query("UPDATE PrisonerDetails pd SET pd.lastVoAllocatedDate = :newLastAllocatedDate WHERE pd.prisonerId = :prisonerId")
   fun updatePrisonerLastVoAllocatedDate(prisonerId: String, newLastAllocatedDate: LocalDate)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderRepository.kt
@@ -110,4 +110,8 @@ interface VisitOrderRepository : JpaRepository<VisitOrder, Long> {
     visitOrderType: VisitOrderType,
     amountToExpire: Long?,
   ): Int
+
+  @Transactional
+  @Modifying
+  fun deleteAllByPrisonerId(prisonerId: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -28,18 +28,22 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
       prisonerDetailsRepository.updatePrisonerLastVoAllocatedDate(prisonerId, newLastAllocatedDate)
     } else {
       // If prisoner does not exist, create a new record
-      createNewPrisonerDetails(prisonerId, newLastAllocatedDate)
+      createNewPrisonerDetails(prisonerId, newLastAllocatedDate, null)
     }
   }
 
-  private fun createNewPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate) {
+  fun createNewPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?) {
     LOG.info("Prisoner $prisonerId not found, creating new record")
     val newPrisoner = PrisonerDetails(
       prisonerId = prisonerId,
       lastVoAllocatedDate = newLastAllocatedDate,
-      lastPvoAllocatedDate = null,
+      lastPvoAllocatedDate = newLastPvoAllocatedDate,
     )
     prisonerDetailsRepository.save(newPrisoner)
+  }
+
+  fun removePrisonerDetails(prisonerId: String) {
+    prisonerDetailsRepository.deleteByPrisonerId(prisonerId)
   }
 
   fun updatePvoLastCreatedDate(prisonerId: String, newLastAllocatedDate: LocalDate) {


### PR DESCRIPTION
Without doing this, we could end up creating the wrong amount of positive / negative VOs (scenario when sync event comes in first).