### PR TITLE
VB-5392 - New endpoint to sync booking changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.visitallocationapi.config.ROLE_VISIT_ALLOCATION_API__NOMIS_API
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerMigrationDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncBookingDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisMigrationService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
@@ -21,6 +22,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 const val VO_NOMIS = "/visits/allocation/prisoner"
 const val VO_PRISONER_MIGRATION: String = "$VO_NOMIS/migrate"
 const val VO_PRISONER_SYNC: String = "$VO_NOMIS/sync"
+const val VO_PRISONER_BOOKING_SYNC: String = "$VO_PRISONER_SYNC/booking"
 
 @RestController
 class NomisController(
@@ -77,7 +79,34 @@ class NomisController(
     ],
   )
   fun syncPrisonerVisitOrders(@RequestBody @Valid visitAllocationPrisonerSyncDto: VisitAllocationPrisonerSyncDto): ResponseEntity<Void> {
-    nomisSyncService.syncPrisoner(visitAllocationPrisonerSyncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(visitAllocationPrisonerSyncDto)
+    return ResponseEntity.status(HttpStatus.OK).build()
+  }
+
+  @PreAuthorize("hasRole('$ROLE_VISIT_ALLOCATION_API__NOMIS_API')")
+  @PostMapping(VO_PRISONER_BOOKING_SYNC)
+  @Operation(
+    summary = "Endpoint to sync booking changes made to a prisoner, which effect their VO / PVO balances from NOMIS to DPS.",
+    description = "Takes a pair of prisoners who have been effected by a booking being moved between them, and their new balances.",
+    responses = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Prisoner information has been synced.",
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorized to access this endpoint.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Incorrect permissions to sync prisoner booking VO / PVO information.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun syncPrisonerBookingVisitOrderChanges(@RequestBody @Valid visitAllocationPrisonerSyncBookingDto: VisitAllocationPrisonerSyncBookingDto): ResponseEntity<Void> {
+    nomisSyncService.syncPrisonerBookingChanges(visitAllocationPrisonerSyncBookingDto)
     return ResponseEntity.status(HttpStatus.OK).build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
@@ -22,7 +22,7 @@ import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 const val VO_NOMIS = "/visits/allocation/prisoner"
 const val VO_PRISONER_MIGRATION: String = "$VO_NOMIS/migrate"
 const val VO_PRISONER_SYNC: String = "$VO_NOMIS/sync"
-const val VO_PRISONER_BOOKING_SYNC: String = "$VO_PRISONER_SYNC/booking"
+const val VO_PRISONER_BOOKING_MOVE_SYNC: String = "$VO_PRISONER_SYNC/booking-move"
 
 @RestController
 class NomisController(
@@ -84,7 +84,7 @@ class NomisController(
   }
 
   @PreAuthorize("hasRole('$ROLE_VISIT_ALLOCATION_API__NOMIS_API')")
-  @PostMapping(VO_PRISONER_BOOKING_SYNC)
+  @PostMapping(VO_PRISONER_BOOKING_MOVE_SYNC)
   @Operation(
     summary = "Endpoint to sync booking changes made to a prisoner, which effect their VO / PVO balances from NOMIS to DPS.",
     description = "Takes a pair of prisoners who have been effected by a booking being moved between them, and their new balances.",
@@ -105,8 +105,8 @@ class NomisController(
       ),
     ],
   )
-  fun syncPrisonerBookingVisitOrderChanges(@RequestBody @Valid visitAllocationPrisonerSyncBookingDto: VisitAllocationPrisonerSyncBookingDto): ResponseEntity<Void> {
-    nomisSyncService.syncPrisonerBookingChanges(visitAllocationPrisonerSyncBookingDto)
+  fun syncPrisonerBookingMoveVisitOrderChanges(@RequestBody @Valid visitAllocationPrisonerSyncBookingDto: VisitAllocationPrisonerSyncBookingDto): ResponseEntity<Void> {
+    nomisSyncService.syncPrisonerBookingMoveChanges(visitAllocationPrisonerSyncBookingDto)
     return ResponseEntity.status(HttpStatus.OK).build()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncBookingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncBookingDto.kt
@@ -1,0 +1,30 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+@Schema(description = "DTO to provide information of 2 prisoners effected by a booking moved between them in NOMIS")
+data class VisitAllocationPrisonerSyncBookingDto(
+  @Schema(description = "nomsNumber of the first prisoner", example = "AA123456", required = true)
+  @field:NotNull
+  @field:NotEmpty
+  val firstPrisonerId: String,
+
+  @Schema(description = "The new VO balance of the first prisoner (can be negative)", example = "5", required = true)
+  val firstPrisonerVoBalance: Int,
+
+  @Schema(description = "The new PVO balance of the first prisoner (can be negative)", example = "1", required = true)
+  val firstPrisonerPvoBalance: Int,
+
+  @Schema(description = "nomsNumber of the second prisoner", example = "AA123456", required = true)
+  @field:NotNull
+  @field:NotEmpty
+  val secondPrisonerId: String,
+
+  @Schema(description = "The new VO balance of the second prisoner (can be negative)", example = "5", required = true)
+  val secondPrisonerVoBalance: Int,
+
+  @Schema(description = "The new PVO balance of the second prisoner (can be negative)", example = "1", required = true)
+  val secondPrisonerPvoBalance: Int,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/ChangeLogType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/ChangeLogType.kt
@@ -4,4 +4,5 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.enums
 enum class ChangeLogType {
   MIGRATION,
   SYNC,
+  SYNC_BOOKING,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
@@ -5,4 +5,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 
 @Repository
-interface ChangeLogRepository : JpaRepository<ChangeLog, Long>
+interface ChangeLogRepository : JpaRepository<ChangeLog, Long> {
+
+  fun findByPrisonerId(prisonerId: String): List<ChangeLog>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
@@ -26,7 +26,7 @@ class BalanceService(
   fun getPrisonerBalance(prisonerId: String): PrisonerBalanceDto? {
     LOG.info("Entered BalanceService - getPrisonerBalance for prisoner $prisonerId")
 
-    // If prisoner doesn't exist in DB, return null
+    // If prisoner doesn't exist in DB, return null. Balance endpoint uses null to throw a NOT_FOUND exception.
     if (prisonerDetailsService.getPrisoner(prisonerId) == null) {
       LOG.info("Prisoner $prisonerId not found in DB, returning null balance")
       return null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -31,7 +31,7 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
     )
   }
 
-  fun logSyncChange(syncDto: VisitAllocationPrisonerSyncDto) {
+  fun logSyncAdjustmentChange(syncDto: VisitAllocationPrisonerSyncDto) {
     LOG.info("Logging sync to change_log table for prisoner ${syncDto.prisonerId}, sync - $syncDto")
     changeLogRepository.save(
       ChangeLog(
@@ -40,6 +40,19 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         comment = "synced prisoner ${syncDto.prisonerId}, with adjustment code ${syncDto.adjustmentReasonCode.name}",
+      ),
+    )
+  }
+
+  fun logSyncBookingChange(prisonerId: String) {
+    LOG.info("Logging booking sync to change_log table for prisoner $prisonerId")
+    changeLogRepository.save(
+      ChangeLog(
+        prisonerId = prisonerId,
+        changeType = ChangeLogType.SYNC_BOOKING,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "synced prisoner $prisonerId, due to booking change on NOMIS",
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -35,7 +35,7 @@ class NomisSyncService(
   }
 
   @Transactional
-  fun syncPrisonerBookingChanges(syncDto: VisitAllocationPrisonerSyncBookingDto) {
+  fun syncPrisonerBookingMoveChanges(syncDto: VisitAllocationPrisonerSyncBookingDto) {
     // In NOMIS, a booking can be moved from one prisoner to another. When this happens, no triggers occur
     // on the adjustments_table, so the sync endpoint is never called. Introducing this new endpoint,
     // for NOMIS to call when a booking is moved, to help us reconcile the balances of both prisoners.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.PrisonerBalanceDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncBookingDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderType
@@ -34,7 +35,25 @@ class NomisSyncService(
   }
 
   @Transactional
-  fun syncPrisoner(syncDto: VisitAllocationPrisonerSyncDto) {
+  fun syncPrisonerBookingChanges(syncDto: VisitAllocationPrisonerSyncBookingDto) {
+    // In NOMIS, a booking can be moved from one prisoner to another. When this happens, no triggers occur
+    // on the adjustments_table, so the sync endpoint is never called. Introducing this new endpoint,
+    // for NOMIS to call when a booking is moved, to help us reconcile the balances of both prisoners.
+    LOG.info("Entered NomisSyncService - syncPrisonerBookingChanges with sync dto {}", syncDto)
+
+    val firstPrisonerNomisBalance = PrisonerBalanceDto(syncDto.firstPrisonerId, syncDto.firstPrisonerVoBalance, syncDto.firstPrisonerPvoBalance)
+    val firstPrisonerDpsBalance = balanceService.getPrisonerBalance(syncDto.firstPrisonerId) ?: PrisonerBalanceDto(syncDto.firstPrisonerId, 0, 0)
+    processSyncBooking(nomisBalance = firstPrisonerNomisBalance, dpsBalance = firstPrisonerDpsBalance)
+
+    val secondPrisonerNomisBalance = PrisonerBalanceDto(syncDto.secondPrisonerId, syncDto.secondPrisonerVoBalance, syncDto.secondPrisonerPvoBalance)
+    val secondPrisonerDpsBalance = balanceService.getPrisonerBalance(syncDto.secondPrisonerId) ?: PrisonerBalanceDto(syncDto.secondPrisonerId, 0, 0)
+    processSyncBooking(nomisBalance = secondPrisonerNomisBalance, dpsBalance = secondPrisonerDpsBalance)
+  }
+
+  @Transactional
+  fun syncPrisonerAdjustmentChanges(syncDto: VisitAllocationPrisonerSyncDto) {
+    // In NOMIS, when a change is made via the adjustments_table, it will trigger a call
+    // to this endpoint, allowing DPS to sync the prisoner vo & pvo balances with NOMIS.
     LOG.info("Entered NomisSyncService - syncPrisoner with sync dto {}", syncDto)
 
     validateSyncRequest(syncDto)
@@ -81,7 +100,29 @@ class NomisSyncService(
       prisonerDetailsService.updateVoLastCreatedDateOrCreatePrisoner(syncDto.prisonerId, syncDto.createdDate)
     }
 
-    changeLogService.logSyncChange(syncDto)
+    changeLogService.logSyncAdjustmentChange(syncDto)
+  }
+
+  private fun processSyncBooking(nomisBalance: PrisonerBalanceDto, dpsBalance: PrisonerBalanceDto) {
+    val prisonerId = nomisBalance.prisonerId
+
+    processSync(
+      prisonerId,
+      dpsBalance.voBalance,
+      calculateAmountToChange(dpsBalance.voBalance, nomisBalance.voBalance, 0),
+      VisitOrderType.VO,
+      NegativeVisitOrderType.NEGATIVE_VO,
+    )
+
+    processSync(
+      prisonerId,
+      dpsBalance.pvoBalance,
+      calculateAmountToChange(dpsBalance.pvoBalance, nomisBalance.pvoBalance, 0),
+      VisitOrderType.PVO,
+      NegativeVisitOrderType.NEGATIVE_PVO,
+    )
+
+    changeLogService.logSyncBookingChange(prisonerId)
   }
 
   private fun processSync(prisonerId: String, prisonerDpsBalance: Int, balanceChange: Int, visitOrderType: VisitOrderType, negativeVoType: NegativeVisitOrderType) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -76,7 +76,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
@@ -87,7 +87,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -106,13 +106,13 @@ class NomisSyncServiceTest {
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
 
     // WHEN
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, 1L)
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.PVO, 1L)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -132,7 +132,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, null)
@@ -144,7 +144,7 @@ class NomisSyncServiceTest {
     val negativePrivilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(negativePrivilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -166,7 +166,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the negative visit orders that were saved
     verify(negativeVisitOrderRepository, times(2)).saveAll(negativeVisitOrderCaptor.capture())
@@ -177,7 +177,7 @@ class NomisSyncServiceTest {
     val privilegedNegativeVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(privilegedNegativeVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -196,13 +196,13 @@ class NomisSyncServiceTest {
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
 
     // WHEN
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, 1)
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_PVO, 1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -222,7 +222,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
@@ -234,7 +234,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -256,7 +256,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
@@ -267,7 +267,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -287,7 +287,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the negative visit orders that were saved
     verify(negativeVisitOrderRepository, times(2)).saveAll(negativeVisitOrderCaptor.capture())
@@ -298,7 +298,7 @@ class NomisSyncServiceTest {
     val privilegedNegativeVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(privilegedNegativeVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -321,7 +321,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
@@ -332,7 +332,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(2)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -365,7 +365,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(2)).saveAll(visitOrderCaptor.capture())
@@ -376,7 +376,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(0)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -409,7 +409,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(negativeVisitOrderRepository, times(2)).saveAll(negativeVisitOrderCaptor.capture())
@@ -420,7 +420,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(2)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -453,7 +453,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(negativeVisitOrderRepository, times(2)).saveAll(negativeVisitOrderCaptor.capture())
@@ -464,7 +464,7 @@ class NomisSyncServiceTest {
     val negativePrivilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(negativePrivilegedVisitOrdersSaved.size).isEqualTo(0)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -497,7 +497,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
@@ -509,7 +509,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -542,7 +542,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, NegativeVisitOrderType.NEGATIVE_VO, null)
@@ -555,7 +555,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -588,7 +588,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, null)
@@ -600,7 +600,7 @@ class NomisSyncServiceTest {
     val negativePrivilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(negativePrivilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,
@@ -634,7 +634,7 @@ class NomisSyncServiceTest {
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
-    nomisSyncService.syncPrisoner(syncDto)
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN - Capture the visit orders that were saved
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, null)
@@ -647,7 +647,7 @@ class NomisSyncServiceTest {
     val negativePrivilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(negativePrivilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
 
     val voTelemetryProperties = createTelemetryVoSyncProperties(
       prisonerId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncBookingTest.kt
@@ -1,0 +1,129 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import uk.gov.justice.digital.hmpps.visitallocationapi.config.ROLE_VISIT_ALLOCATION_API__NOMIS_API
+import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_PRISONER_BOOKING_SYNC
+import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_PRISONER_SYNC
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncBookingDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper.callPost
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import java.time.LocalDate
+
+@DisplayName("NomisController sync booking tests - $VO_PRISONER_BOOKING_SYNC")
+class NomisControllerSyncBookingTest : IntegrationTestBase() {
+
+  companion object {
+    const val FIRST_PRISONER_ID = "AA123456"
+    const val SECOND_PRISONER_ID = "BB123456"
+  }
+
+  /**
+   * Scenario 1: Existing Prisoner who has a positive balance which is in sync, has an increase to their balance. DPS syncs successfully.
+   */
+  @Test
+  fun `when a booking sync request comes in, then both prisoners who are effected are successfully processed and synced`() {
+    // Given
+    entityHelper.createAndSaveVisitOrders(prisonerId = FIRST_PRISONER_ID, VisitOrderType.VO, 2)
+    entityHelper.createAndSaveVisitOrders(prisonerId = FIRST_PRISONER_ID, VisitOrderType.PVO, 1)
+    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = FIRST_PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    entityHelper.createAndSaveVisitOrders(prisonerId = SECOND_PRISONER_ID, VisitOrderType.VO, 2)
+    entityHelper.createAndSaveVisitOrders(prisonerId = SECOND_PRISONER_ID, VisitOrderType.PVO, 1)
+    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = SECOND_PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    val syncDto = VisitAllocationPrisonerSyncBookingDto(
+      firstPrisonerId = FIRST_PRISONER_ID,
+      firstPrisonerVoBalance = 4,
+      firstPrisonerPvoBalance = 2,
+      secondPrisonerId = SECOND_PRISONER_ID,
+      secondPrisonerVoBalance = 2,
+      secondPrisonerPvoBalance = 1,
+    )
+
+    // When
+    val responseSpec = callVisitAllocationSyncBookingEndpoint(webTestClient, syncDto, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
+
+    // Then
+    responseSpec.expectStatus().isOk
+    assertBookingSyncResults(FIRST_PRISONER_ID, 4, 2)
+    assertBookingSyncResults(SECOND_PRISONER_ID, 2, 1)
+  }
+
+  @Test
+  fun `when request body validation fails then 400 bad request is returned`() {
+    // Given
+    val syncDto = VisitAllocationPrisonerSyncBookingDto(
+      firstPrisonerId = "",
+      firstPrisonerVoBalance = 4,
+      firstPrisonerPvoBalance = 2,
+      secondPrisonerId = SECOND_PRISONER_ID,
+      secondPrisonerVoBalance = 2,
+      secondPrisonerPvoBalance = 1,
+    )
+    // When
+    val responseSpec = callVisitAllocationSyncBookingEndpoint(webTestClient, syncDto, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
+
+    // Then
+    responseSpec.expectStatus().isBadRequest
+  }
+
+  @Test
+  fun `access forbidden when no role`() {
+    // Given
+    val incorrectAuthHeaders = setAuthorisation(roles = listOf())
+    val syncDto = VisitAllocationPrisonerSyncBookingDto(
+      firstPrisonerId = FIRST_PRISONER_ID,
+      firstPrisonerVoBalance = 4,
+      firstPrisonerPvoBalance = 2,
+      secondPrisonerId = SECOND_PRISONER_ID,
+      secondPrisonerVoBalance = 2,
+      secondPrisonerPvoBalance = 1,
+    )
+    // When
+    val responseSpec = callVisitAllocationSyncBookingEndpoint(webTestClient, syncDto, incorrectAuthHeaders)
+
+    // Then
+    responseSpec.expectStatus().isForbidden
+  }
+
+  @Test
+  fun `unauthorised when no token`() {
+    // Given no auth token
+
+    // When
+    val responseSpec = webTestClient.post().uri(VO_PRISONER_SYNC).exchange()
+
+    // Then
+    responseSpec.expectStatus().isUnauthorized
+  }
+
+  private fun callVisitAllocationSyncBookingEndpoint(
+    webTestClient: WebTestClient,
+    dto: VisitAllocationPrisonerSyncBookingDto? = null,
+    authHttpHeaders: (HttpHeaders) -> Unit,
+  ): ResponseSpec = callPost(
+    dto,
+    webTestClient,
+    VO_PRISONER_BOOKING_SYNC,
+    authHttpHeaders,
+  )
+
+  private fun assertBookingSyncResults(prisonerId: String, expectedVoCount: Int, expectedPvoCount: Int) {
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders.filter { it.prisonerId == prisonerId && it.status == VisitOrderStatus.AVAILABLE && it.type == VisitOrderType.VO }.size).isEqualTo(expectedVoCount)
+    assertThat(visitOrders.filter { it.prisonerId == prisonerId && it.status == VisitOrderStatus.AVAILABLE && it.type == VisitOrderType.PVO }.size).isEqualTo(expectedPvoCount)
+
+    val changeLogs = changeLogRepository.findByPrisonerId(prisonerId)
+    assertThat(changeLogs.size).isEqualTo(1)
+    assertThat(changeLogs.first().prisonerId).isEqualTo(prisonerId)
+    assertThat(changeLogs.first().changeType).isEqualTo(ChangeLogType.SYNC_BOOKING)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncBookingTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncBookingTest.kt
@@ -7,7 +7,7 @@ import org.springframework.http.HttpHeaders
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
 import uk.gov.justice.digital.hmpps.visitallocationapi.config.ROLE_VISIT_ALLOCATION_API__NOMIS_API
-import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_PRISONER_BOOKING_SYNC
+import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_PRISONER_BOOKING_MOVE_SYNC
 import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_PRISONER_SYNC
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncBookingDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
@@ -17,7 +17,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper.callPo
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import java.time.LocalDate
 
-@DisplayName("NomisController sync booking tests - $VO_PRISONER_BOOKING_SYNC")
+@DisplayName("NomisController sync booking tests - $VO_PRISONER_BOOKING_MOVE_SYNC")
 class NomisControllerSyncBookingTest : IntegrationTestBase() {
 
   companion object {
@@ -112,7 +112,7 @@ class NomisControllerSyncBookingTest : IntegrationTestBase() {
   ): ResponseSpec = callPost(
     dto,
     webTestClient,
-    VO_PRISONER_BOOKING_SYNC,
+    VO_PRISONER_BOOKING_MOVE_SYNC,
     authHttpHeaders,
   )
 


### PR DESCRIPTION
## What does this PR do?
In NOMIS, a booking can be moved between 2 prisoners. As the VO/PVO balance is stored against bookings on NOMIS, moving it can change the balance.

This endpoint allows NOMIS to tell visit-allocation-api of the change so it can sync.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5392