### PR TITLE
Update database and JPA entities to use relationships

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
@@ -7,20 +7,19 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "CHANGE_LOG")
+@Table(name = "change_log")
 data class ChangeLog(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,
-
-  @Column(nullable = false)
-  val prisonerId: String,
 
   @Column(nullable = false)
   val changeTimestamp: LocalDateTime = LocalDateTime.now(),
@@ -36,6 +35,15 @@ data class ChangeLog(
   @Column(nullable = false)
   val userId: String,
 
-  @Column(nullable = false)
+  @Column(nullable = true)
   val comment: String? = null,
+
+  // This column will be for the foreign key
+  @Column(name = "prisoner_id", nullable = false)
+  val prisonerId: String,
+
+  // Specify the relationship and use the existing prisonerId column
+  @ManyToOne
+  @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
+  val prisoner: PrisonerDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
@@ -7,6 +7,8 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
@@ -14,14 +16,11 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "NEGATIVE_VISIT_ORDER")
+@Table(name = "negative_visit_order")
 data class NegativeVisitOrder(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,
-
-  @Column(nullable = false)
-  val prisonerId: String,
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -36,4 +35,13 @@ data class NegativeVisitOrder(
 
   @Column(nullable = false)
   val repaidDate: LocalDate? = null,
+
+  // This column will be for the foreign key
+  @Column(name = "prisoner_id", nullable = false)
+  val prisonerId: String,
+
+  // Specify the relationship and use the existing prisonerId column
+  @ManyToOne
+  @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
+  val prisoner: PrisonerDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
@@ -7,7 +7,7 @@ import jakarta.persistence.Table
 import java.time.LocalDate
 
 @Entity
-@Table(name = "PRISONER_DETAILS")
+@Table(name = "prisoner_details")
 data class PrisonerDetails(
   @Id
   @Column(nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
@@ -7,6 +7,8 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
@@ -14,14 +16,11 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 
 @Entity
-@Table(name = "VISIT_ORDER")
+@Table(name = "visit_order")
 data class VisitOrder(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,
-
-  @Column(nullable = false)
-  val prisonerId: String,
 
   @Column(nullable = false)
   @Enumerated(EnumType.STRING)
@@ -36,4 +35,13 @@ data class VisitOrder(
 
   @Column(nullable = false)
   val expiryDate: LocalDate? = null,
+
+  // This column will be for the foreign key
+  @Column(name = "prisoner_id", nullable = false)
+  val prisonerId: String,
+
+  // Specify the relationship and use the existing prisonerId column
+  @ManyToOne
+  @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
+  val prisoner: PrisonerDetails,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
@@ -1,10 +1,19 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 
 @Repository
 interface ChangeLogRepository : JpaRepository<ChangeLog, Long> {
+  @Transactional
+  @Modifying
+  @Query(
+    value = "DELETE FROM change_log WHERE prisoner_id = :prisonerId",
+    nativeQuery = true,
+  )
   fun deleteAllByPrisonerId(prisonerId: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/NegativeVisitOrderRepository.kt
@@ -24,7 +24,14 @@ interface NegativeVisitOrderRepository : JpaRepository<NegativeVisitOrder, Long>
   ): List<PrisonerBalance>
 
   @Query(
-    "SELECT COUNT(nvo) FROM NegativeVisitOrder nvo WHERE nvo.prisonerId = :prisonerId AND nvo.type = :type AND nvo.status = :status",
+    value = """
+    SELECT COUNT(*) 
+    FROM negative_visit_order 
+    WHERE prisoner_id = :prisonerId 
+      AND type = :#{#type.name()}
+      AND status = :#{#status.name()}
+  """,
+    nativeQuery = true,
   )
   fun countAllNegativeVisitOrders(
     prisonerId: String,
@@ -58,5 +65,9 @@ interface NegativeVisitOrderRepository : JpaRepository<NegativeVisitOrder, Long>
 
   @Transactional
   @Modifying
+  @Query(
+    value = "DELETE FROM negative_visit_order WHERE prisoner_id = :prisonerId",
+    nativeQuery = true,
+  )
   fun deleteAllByPrisonerId(prisonerId: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderRepository.kt
@@ -24,7 +24,14 @@ interface VisitOrderRepository : JpaRepository<VisitOrder, Long> {
   ): List<PrisonerBalance>
 
   @Query(
-    "SELECT COUNT(vo) FROM VisitOrder vo WHERE vo.prisonerId = :prisonerId AND vo.type = :type AND vo.status = :status",
+    value = """
+    SELECT COUNT(*) 
+    FROM visit_order 
+    WHERE prisoner_id = :prisonerId 
+      AND type = :#{#type.name()}
+      AND status = :#{#status.name()}
+  """,
+    nativeQuery = true,
   )
   fun countAllVisitOrders(
     prisonerId: String,
@@ -113,5 +120,9 @@ interface VisitOrderRepository : JpaRepository<VisitOrder, Long> {
 
   @Transactional
   @Modifying
+  @Query(
+    value = "DELETE FROM visit_order WHERE prisoner_id = :prisonerId",
+    nativeQuery = true,
+  )
   fun deleteAllByPrisonerId(prisonerId: String)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
 
 @Transactional
@@ -19,7 +20,7 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun logMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto) {
+  fun logMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto, dpsPrisoner: PrisonerDetails) {
     LOG.info("Logging migration to change_log table for prisoner ${migrationChangeDto.prisonerId}, migration - $migrationChangeDto")
     changeLogRepository.save(
       ChangeLog(
@@ -28,11 +29,12 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         comment = "migrated prisoner ${migrationChangeDto.prisonerId}, with vo balance ${migrationChangeDto.voBalance} and pvo balance ${migrationChangeDto.pvoBalance} and lastAllocatedDate ${migrationChangeDto.lastVoAllocationDate}",
+        prisoner = dpsPrisoner,
       ),
     )
   }
 
-  fun logSyncAdjustmentChange(syncDto: VisitAllocationPrisonerSyncDto) {
+  fun logSyncAdjustmentChange(syncDto: VisitAllocationPrisonerSyncDto, dpsPrisoner: PrisonerDetails) {
     LOG.info("Logging sync to change_log table for prisoner ${syncDto.prisonerId}, sync - $syncDto")
     changeLogRepository.save(
       ChangeLog(
@@ -41,11 +43,12 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         comment = "synced prisoner ${syncDto.prisonerId}, with adjustment code ${syncDto.adjustmentReasonCode.name}",
+        prisoner = dpsPrisoner,
       ),
     )
   }
 
-  fun logSyncEventChange(prisonerId: String, domainEventType: DomainEventType) {
+  fun logSyncEventChange(prisonerId: String, domainEventType: DomainEventType, dpsPrisoner: PrisonerDetails) {
     LOG.info("Logging sync to change_log table for prisoner $prisonerId, event - ${domainEventType.value}")
     changeLogRepository.save(
       ChangeLog(
@@ -54,6 +57,7 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         comment = "synced prisoner $prisonerId, with domain event ${domainEventType.value}",
+        prisoner = dpsPrisoner,
       ),
     )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -17,29 +17,20 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun getPrisoner(prisonerId: String): PrisonerDetails? = prisonerDetailsRepository.findByPrisonerId(prisonerId)
 
-  fun updateVoLastCreatedDateOrCreatePrisoner(prisonerId: String, newLastAllocatedDate: LocalDate) {
-    LOG.info("Entered PrisonerDetailsService updateVoLastCreatedDateOrCreatePrisoner for prisoner $prisonerId with date $newLastAllocatedDate")
-    // Check if the prisoner exists
-    val prisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId)
+  fun updateVoLastCreatedDate(prisonerId: String, newLastAllocatedDate: LocalDate) {
+    LOG.info("Entered PrisonerDetailsService updateVoLastCreatedDate for prisoner $prisonerId with date $newLastAllocatedDate")
 
-    if (prisonerDetails != null) {
-      LOG.info("Existing prisoner $prisonerId found - Updating last VO allocated date to $newLastAllocatedDate")
-      // If prisoner exists, update the record
-      prisonerDetailsRepository.updatePrisonerLastVoAllocatedDate(prisonerId, newLastAllocatedDate)
-    } else {
-      // If prisoner does not exist, create a new record
-      createNewPrisonerDetails(prisonerId, newLastAllocatedDate, null)
-    }
+    prisonerDetailsRepository.updatePrisonerLastVoAllocatedDate(prisonerId, newLastAllocatedDate)
   }
 
-  fun createNewPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?) {
+  fun createNewPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("Prisoner $prisonerId not found, creating new record")
     val newPrisoner = PrisonerDetails(
       prisonerId = prisonerId,
       lastVoAllocatedDate = newLastAllocatedDate,
       lastPvoAllocatedDate = newLastPvoAllocatedDate,
     )
-    prisonerDetailsRepository.save(newPrisoner)
+    return prisonerDetailsRepository.save(newPrisoner)
   }
 
   fun removePrisonerDetails(prisonerId: String) {

--- a/src/main/resources/db/migration/V1_10__alter_tables_add_final_constraints.sql
+++ b/src/main/resources/db/migration/V1_10__alter_tables_add_final_constraints.sql
@@ -1,0 +1,21 @@
+BEGIN;
+
+-- Add foreign key constraint between visit_order and prisoner_details
+ALTER TABLE visit_order
+    ADD CONSTRAINT fk_visit_order_prisoner_id
+        FOREIGN KEY (prisoner_id) REFERENCES prisoner_details (prisoner_id)
+            ON DELETE CASCADE;
+
+-- Add foreign key constraint between negative_visit_order and prisoner_details
+ALTER TABLE negative_visit_order
+    ADD CONSTRAINT fk_negative_visit_order_prisoner_id
+        FOREIGN KEY (prisoner_id) REFERENCES prisoner_details (prisoner_id)
+            ON DELETE CASCADE;
+
+-- Add foreign key constraint between change_log and prisoner_details
+ALTER TABLE change_log
+    ADD CONSTRAINT fk_change_log_prisoner_id
+        FOREIGN KEY (prisoner_id) REFERENCES prisoner_details (prisoner_id)
+            ON DELETE CASCADE;
+
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/AllocationServiceTest.kt
@@ -80,6 +80,7 @@ class AllocationServiceTest {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
     val prisoner = createPrisonerDto(prisonerId, prisonId, "IN")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD")
 
@@ -87,6 +88,7 @@ class AllocationServiceTest {
     whenever(prisonerSearchClient.getPrisonerById(prisonerId)).thenReturn(prisoner)
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(prisoner.prisonerId)).thenReturn(prisonerIncentive)
     whenever(incentivesClient.getPrisonIncentiveLevelByLevelCode(prisoner.prisonId, prisonerIncentive.iepCode)).thenReturn(prisonIncentiveAmounts)
+    whenever(prisonerDetailsService.createNewPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)).thenReturn(dpsPrisoner)
 
     // Begin test
     runBlocking {
@@ -120,6 +122,7 @@ class AllocationServiceTest {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
     val prisoner = createPrisonerDto(prisonerId, prisonId, "IN")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD")
 
@@ -135,6 +138,7 @@ class AllocationServiceTest {
     )
     whenever(incentivesClient.getPrisonIncentiveLevels(prisonId)).thenReturn(listOf(prisonIncentiveAmounts))
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(prisoner.prisonerId)).thenReturn(prisonerIncentive)
+    whenever(prisonerDetailsService.createNewPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)).thenReturn(dpsPrisoner)
 
     // Begin test
     runBlocking {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -7,6 +7,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyNoInteractions
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.AdjustmentReasonCode
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepository
@@ -72,9 +74,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = 2, changeToVoBalance = 2, oldPvoBalance = 1, changeToPvoBalance = 1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 2, pvoBalance = 1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
@@ -89,7 +93,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -103,9 +107,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = 2, changeToVoBalance = -1, oldPvoBalance = 1, changeToPvoBalance = -1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 2, pvoBalance = 1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
@@ -114,7 +120,7 @@ class NomisSyncServiceTest {
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, 1L)
     verify(visitOrderRepository, times(1)).expireVisitOrdersGivenAmount(prisonerId, VisitOrderType.PVO, 1L)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -128,9 +134,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = 2, changeToVoBalance = -3, oldPvoBalance = 1, changeToPvoBalance = -2)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 2, pvoBalance = 1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
@@ -146,7 +154,7 @@ class NomisSyncServiceTest {
     val negativePrivilegedVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(negativePrivilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -162,9 +170,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = -2, changeToVoBalance = -2, oldPvoBalance = -1, changeToPvoBalance = -1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = -2, pvoBalance = -1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
@@ -179,7 +189,7 @@ class NomisSyncServiceTest {
     val privilegedNegativeVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(privilegedNegativeVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -193,9 +203,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = -2, changeToVoBalance = 1, oldPvoBalance = -1, changeToPvoBalance = 1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = -2, pvoBalance = -1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
@@ -204,7 +216,7 @@ class NomisSyncServiceTest {
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, VisitOrderType.VO, 1)
     verify(negativeVisitOrderRepository, times(1)).repayNegativeVisitOrdersGivenAmount(prisonerId, VisitOrderType.PVO, 1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -218,9 +230,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = -2, changeToVoBalance = 3, oldPvoBalance = -1, changeToPvoBalance = 2)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = -2, pvoBalance = -1)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
@@ -236,7 +250,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -252,9 +266,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = 0, changeToVoBalance = 2, oldPvoBalance = 0, changeToPvoBalance = 1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 0, pvoBalance = 0)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()
@@ -269,7 +285,7 @@ class NomisSyncServiceTest {
     val privilegedVisitOrdersSaved = visitOrderCaptor.allValues[1]
     assertThat(privilegedVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -283,9 +299,11 @@ class NomisSyncServiceTest {
     val prisonerId = PRISONER_ID
     val syncDto = createSyncRequest(prisonerId = prisonerId, oldVoBalance = 0, changeToVoBalance = -2, oldPvoBalance = 0, changeToPvoBalance = -1)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 0, pvoBalance = 0)
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val negativeVisitOrderCaptor = argumentCaptor<List<NegativeVisitOrder>>()
@@ -300,7 +318,7 @@ class NomisSyncServiceTest {
     val privilegedNegativeVisitOrdersSaved = negativeVisitOrderCaptor.allValues[1]
     assertThat(privilegedNegativeVisitOrdersSaved.size).isEqualTo(1)
 
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(syncDto)
+    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -314,12 +332,14 @@ class NomisSyncServiceTest {
   fun `Given a prisoner event comes through, then balance is synced`() {
     // GIVEN
     val prisonerId = PRISONER_ID
+    val existingPrisonerDetails = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), lastPvoAllocatedDate = null)
     val existingPrisonerBalance = PrisonerBalanceDto(prisonerId = prisonerId, voBalance = 2, pvoBalance = 1)
     val existingNomisBalance = VisitBalancesDto(remainingVo = 3, remainingPvo = 2, latestIepAdjustDate = LocalDate.now().minusDays(1), latestPrivIepAdjustDate = LocalDate.now().minusDays(1))
 
     // WHEN
     whenever(balanceService.getPrisonerBalance(prisonerId)).thenReturn(existingPrisonerBalance)
     whenever(prisonApiClient.getBookingVisitBalances(prisonerId)).thenReturn(existingNomisBalance)
+    whenever(prisonerDetailsService.getPrisoner(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
     val visitOrderCaptor = argumentCaptor<List<VisitOrder>>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/BalanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/BalanceControllerTest.kt
@@ -28,10 +28,10 @@ class BalanceControllerTest : IntegrationTestBase() {
   @Test
   fun `when request to get existing prisoner with positive balance, then return prisoner balance`() {
     // Given
-    visitOrderRepository.save(VisitOrder(prisonerId = PRISONER_ID, type = VisitOrderType.VO, status = VisitOrderStatus.AVAILABLE))
-    visitOrderRepository.save(VisitOrder(prisonerId = PRISONER_ID, type = VisitOrderType.VO, status = VisitOrderStatus.EXPIRED))
-    visitOrderRepository.save(VisitOrder(prisonerId = PRISONER_ID, type = VisitOrderType.PVO, status = VisitOrderStatus.AVAILABLE))
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now(), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now(), lastPvoAllocatedDate = null))
+    visitOrderRepository.save(VisitOrder(prisonerId = prisoner.prisonerId, type = VisitOrderType.VO, status = VisitOrderStatus.AVAILABLE, prisoner = prisoner))
+    visitOrderRepository.save(VisitOrder(prisonerId = prisoner.prisonerId, type = VisitOrderType.VO, status = VisitOrderStatus.EXPIRED, prisoner = prisoner))
+    visitOrderRepository.save(VisitOrder(prisonerId = prisoner.prisonerId, type = VisitOrderType.PVO, status = VisitOrderStatus.AVAILABLE, prisoner = prisoner))
 
     // When
     val responseSpec = callVisitAllocationPrisonerBalanceEndpoint(PRISONER_ID, webTestClient, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
@@ -48,9 +48,9 @@ class BalanceControllerTest : IntegrationTestBase() {
   @Test
   fun `when request to get existing prisoner with negative balance, then return prisoner balance`() {
     // Given
-    negativeVisitOrderRepository.save(NegativeVisitOrder(prisonerId = PRISONER_ID, type = VisitOrderType.VO, status = NegativeVisitOrderStatus.USED))
-    negativeVisitOrderRepository.save(NegativeVisitOrder(prisonerId = PRISONER_ID, type = VisitOrderType.PVO, status = NegativeVisitOrderStatus.USED))
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now(), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now(), lastPvoAllocatedDate = null))
+    negativeVisitOrderRepository.save(NegativeVisitOrder(prisonerId = prisoner.prisonerId, type = VisitOrderType.VO, status = NegativeVisitOrderStatus.USED, prisoner = prisoner))
+    negativeVisitOrderRepository.save(NegativeVisitOrder(prisonerId = prisoner.prisonerId, type = VisitOrderType.PVO, status = NegativeVisitOrderStatus.USED, prisoner = prisoner))
 
     // When
     val responseSpec = callVisitAllocationPrisonerBalanceEndpoint(PRISONER_ID, webTestClient, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
@@ -156,8 +156,8 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
   @Test
   fun `when visit prisoner allocation migration endpoint is called with an existing prisoner, then prisoner information is reset and then successfully migrated to DPS service`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = "AA123456", visitOrderType = VisitOrderType.VO, amountToCreate = 1)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = "AA123456", lastVoAllocatedDate = LocalDate.now().minusDays(1), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = "AA123456", lastVoAllocatedDate = LocalDate.now().minusDays(1), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = "AA123456", visitOrderType = VisitOrderType.VO, amountToCreate = 1, prisoner)
 
     val prisonerMigrationDto = VisitAllocationPrisonerMigrationDto("AA123456", 5, 2, LocalDate.now().minusDays(1))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
@@ -33,9 +33,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `two requests, any order, results in correct balance at the end`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 10)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 5)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 10, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 5, prisoner)
 
     val firstSyncRequest = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -74,9 +74,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a positive balance increases, then DPS service successfully syncs`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -101,9 +101,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a negative balance decreases, then DPS service successfully syncs`() {
     // Given
-    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
-    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5, prisoner)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -129,9 +129,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a positive balance decreases below zero, then DPS service successfully syncs`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -157,9 +157,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with a negative balance increases above zero, then DPS service successfully syncs`() {
     // Given
-    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveNegativeVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -230,9 +230,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with only a PVO balance change, then VO processing is skipped`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -257,9 +257,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with only a VO balance change, then PVO processing is skipped`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 5, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 2, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -308,9 +308,9 @@ class NomisControllerSyncTest : IntegrationTestBase() {
   @Test
   fun `when an existing prisoner with an out of sync (NOMIS higher) positive balance increases, then DPS service successfully syncs`() {
     // Given
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 4)
-    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1)
-    prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    val prisoner = prisonerDetailsRepository.save(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.VO, 4, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = PRISONER_ID, VisitOrderType.PVO, 1, prisoner)
 
     val prisonerSyncDto = createSyncRequest(
       prisonerId = PRISONER_ID,
@@ -453,7 +453,7 @@ class NomisControllerSyncTest : IntegrationTestBase() {
 
     val changeLogs = changeLogRepository.findAll()
     assertThat(changeLogs.size).isEqualTo(1)
-    assertThat(changeLogs.first().prisonerId).isEqualTo(prisonerSyncDto.prisonerId)
+    assertThat(changeLogs.first().prisoner.prisonerId).isEqualTo(prisonerSyncDto.prisonerId)
     assertThat(changeLogs.first().changeType).isEqualTo(ChangeLogType.SYNC)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -30,13 +30,13 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     val prisonId = "HEI"
     val lastPrisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1)
+    val movedFromPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2, movedFromPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1, movedFromPrisoner)
 
-    entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1)
+    val movedToPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2, movedToPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1, movedToPrisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE.value,
@@ -58,7 +58,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(2)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -93,7 +93,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(2)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -116,13 +116,13 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     val prisonId = "HEI"
     val lastPrisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1)
+    val movedFromPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2, movedFromPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1, movedFromPrisoner)
 
-    entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1)
+    val movedToPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2, movedToPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1, movedToPrisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE.value,
@@ -152,16 +152,14 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     // Given
     val movedFromPrisonerId = "AA123456"
     val movedToPrisonerId = "BB654321"
-    val prisonId = "HEI"
-    val lastPrisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1)
+    val movedFromPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedFromPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.VO, 2, movedFromPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedFromPrisonerId, VisitOrderType.PVO, 1, movedFromPrisoner)
 
-    entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1)
+    val movedToPrisoner = entityHelper.createPrisonerDetails(prisonerId = movedToPrisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.VO, 2, movedToPrisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = movedToPrisonerId, VisitOrderType.PVO, 1, movedToPrisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE.value,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
@@ -29,9 +29,9 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.CONVICTION_STATUS_UPDATED_EVENT_TYPE.value,
@@ -50,7 +50,7 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -63,9 +63,9 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.CONVICTION_STATUS_UPDATED_EVENT_TYPE.value,
@@ -91,9 +91,9 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.CONVICTION_STATUS_UPDATED_EVENT_TYPE.value,
@@ -119,9 +119,9 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.CONVICTION_STATUS_UPDATED_EVENT_TYPE.value,
@@ -167,7 +167,7 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
@@ -29,9 +29,9 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     val removedPrisonerId = "BB123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_MERGED_EVENT_TYPE.value,
@@ -51,7 +51,7 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerRemoved(any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -68,9 +68,9 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val removedPrisonerId = "BB123456"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_MERGED_EVENT_TYPE.value,
@@ -96,9 +96,9 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val removedPrisonerId = "BB123456"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_MERGED_EVENT_TYPE.value,
@@ -143,7 +143,7 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerRemoved(any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
@@ -29,9 +29,9 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RECEIVED_EVENT_TYPE.value,
@@ -50,7 +50,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -63,9 +63,9 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RECEIVED_EVENT_TYPE.value,
@@ -90,9 +90,9 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RECEIVED_EVENT_TYPE.value,
@@ -134,7 +134,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
@@ -30,9 +30,9 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RELEASED_EVENT_TYPE.value,
@@ -51,7 +51,7 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -64,9 +64,9 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RELEASED_EVENT_TYPE.value,
@@ -91,9 +91,9 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     val prisonerId = "AA123456"
     val prisonId = "HEI"
 
-    entityHelper.createPrisonerDetails(prisonerId = prisonerId)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2)
-    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1)
+    val prisoner = entityHelper.createPrisonerDetails(prisonerId = prisonerId)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.VO, 2, prisoner)
+    entityHelper.createAndSaveVisitOrders(prisonerId = prisonerId, VisitOrderType.PVO, 1, prisoner)
 
     val domainEvent = createDomainEventJson(
       DomainEventType.PRISONER_RECEIVED_EVENT_TYPE.value,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderS
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderPrison
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
@@ -33,19 +34,18 @@ class EntityHelper(
   }
 
   @Transactional
-  fun createPrisonerDetails(prisonerId: String) {
-    prisonerDetailsService.createNewPrisonerDetails(prisonerId = prisonerId, newLastAllocatedDate = LocalDate.now(), newLastPvoAllocatedDate = LocalDate.now())
-  }
+  fun createPrisonerDetails(prisonerId: String): PrisonerDetails = prisonerDetailsService.createNewPrisonerDetails(prisonerId = prisonerId, newLastAllocatedDate = LocalDate.now(), newLastPvoAllocatedDate = LocalDate.now())
 
   @Transactional
-  fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, amountToCreate: Int) {
+  fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, amountToCreate: Int, prisoner: PrisonerDetails) {
     val visitOrders = mutableListOf<VisitOrder>()
     repeat(amountToCreate) {
       visitOrders.add(
         VisitOrder(
-          prisonerId = prisonerId,
+          prisonerId = prisoner.prisonerId,
           type = visitOrderType,
           status = VisitOrderStatus.AVAILABLE,
+          prisoner = prisoner,
         ),
       )
     }
@@ -53,14 +53,15 @@ class EntityHelper(
   }
 
   @Transactional
-  fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: VisitOrderType, amountToCreate: Int) {
+  fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: VisitOrderType, amountToCreate: Int, prisoner: PrisonerDetails) {
     val negativeVisitOrders = mutableListOf<NegativeVisitOrder>()
     repeat(amountToCreate) {
       negativeVisitOrders.add(
         NegativeVisitOrder(
-          prisonerId = prisonerId,
+          prisonerId = prisoner.prisonerId,
           type = negativeVoType,
           status = NegativeVisitOrderStatus.USED,
+          prisoner = prisoner,
         ),
       )
     }


### PR DESCRIPTION
## What does this PR do?
Now we have a stable version of our initial database we can complete the initial relationships between the prisoner_details table and the supporting tables (visit_order, negative_visit_order and change_log).

A lot of small changes across the whole service to use the relationship and pass in the prisoner entity into the supporting entities.

## Requirement
Clear out any data in each DB when deploying to envs.