### PR TITLE
VB-5514 - Capture prisoner balance in change log table

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentRequestDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.NotNull
+
+data class VisitAllocationPrisonerAdjustmentRequestDto(
+  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:NotNull
+  @field:NotEmpty
+  val prisonerId: String,
+
+  @Schema(description = "The change log (adjustments) ID", example = "123456", required = true)
+  @field:NotNull
+  val changeLogId: Long,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
@@ -13,7 +13,7 @@ data class VisitAllocationPrisonerAdjustmentResponseDto(
   @Schema(description = "change to previous VO balance (can be negative)", example = "-1", required = false)
   val changeToVoBalance: Int?,
 
-  @Schema(description = "previous PVO balance of prisoner (can be negative)", example = "AA123456", required = false)
+  @Schema(description = "previous PVO balance of prisoner (can be negative)", example = "1", required = false)
   val pvoBalance: Int?,
 
   @Schema(description = "change to previous PVO balance (can be negative)", example = "-1", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
+
+data class VisitAllocationPrisonerAdjustmentResponseDto(
+  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  val prisonerId: String,
+
+  @Schema(description = "previous VO balance of prisoner (can be negative)", example = "2", required = false)
+  val voBalance: Int?,
+
+  @Schema(description = "change to previous VO balance (can be negative)", example = "-1", required = false)
+  val changeToVoBalance: Int?,
+
+  @Schema(description = "previous PVO balance of prisoner (can be negative)", example = "AA123456", required = false)
+  val pvoBalance: Int?,
+
+  @Schema(description = "change to previous PVO balance (can be negative)", example = "-1", required = false)
+  val changeToPvoBalance: Int?,
+
+  @Schema(description = "type of change applied", example = "SYNC", required = true)
+  val changeLogType: ChangeLogType,
+
+  @Schema(description = "additional information of change applied", example = "Gave prisoner extra VO", required = false)
+  val comment: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
@@ -41,6 +41,12 @@ data class ChangeLog(
   @Column(name = "prisoner_id", nullable = false)
   val prisonerId: String,
 
+  @Column(nullable = false)
+  val visitOrderBalance: Int,
+
+  @Column(nullable = false)
+  val privilegedVisitOrderBalance: Int,
+
   @ManyToOne
   @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
   val prisoner: PrisonerDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
@@ -5,4 +5,6 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 
 @Repository
-interface ChangeLogRepository : JpaRepository<ChangeLog, Long>
+interface ChangeLogRepository : JpaRepository<ChangeLog, Long> {
+  fun findAllByPrisonerId(prisonerId: String): List<ChangeLog>?
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -1,17 +1,8 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
 import org.springframework.stereotype.Repository
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 
 @Repository
-interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, Long> {
-  @Transactional
-  fun findByPrisonerId(prisonerId: String): PrisonerDetails?
-
-  @Transactional
-  @Modifying
-  fun deleteByPrisonerId(prisonerId: String)
-}
+interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
@@ -5,10 +5,6 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.PrisonerBalanceDto
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 
 @Service
 class BalanceService(private val prisonerDetailsService: PrisonerDetailsService) {
@@ -27,16 +23,6 @@ class BalanceService(private val prisonerDetailsService: PrisonerDetailsService)
         return null
       }
 
-    return PrisonerBalanceDto(
-      prisonerId = prisonerId,
-      voBalance = getVoBalance(prisonerDetails),
-      pvoBalance = getPvoBalance(prisonerDetails),
-    )
+    return prisonerDetails.getBalance()
   }
-
-  private fun getVoBalance(prisonerDetails: PrisonerDetails): Int = prisonerDetails.visitOrders.count { it.type == VisitOrderType.VO && it.status in listOf(VisitOrderStatus.AVAILABLE, VisitOrderStatus.ACCUMULATED) }
-    .minus(prisonerDetails.negativeVisitOrders.count { it.type == VisitOrderType.VO && it.status == NegativeVisitOrderStatus.USED })
-
-  private fun getPvoBalance(prisonerDetails: PrisonerDetails): Int = prisonerDetails.visitOrders.count { it.type == VisitOrderType.PVO && it.status in listOf(VisitOrderStatus.AVAILABLE) }
-    .minus(prisonerDetails.negativeVisitOrders.count { it.type == VisitOrderType.PVO && it.status == NegativeVisitOrderStatus.USED })
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -11,16 +11,15 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
-import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
 
 @Transactional
 @Service
-class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
+class ChangeLogService {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun logMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto, dpsPrisoner: PrisonerDetails): ChangeLog {
+  fun createLogMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto, dpsPrisoner: PrisonerDetails): ChangeLog {
     LOG.info("Logging migration to change_log table for prisoner ${migrationChangeDto.prisonerId}, migration - $migrationChangeDto")
     return ChangeLog(
       prisonerId = dpsPrisoner.prisonerId,
@@ -29,10 +28,12 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
       userId = "SYSTEM",
       comment = "migrated prisoner ${dpsPrisoner.prisonerId}, with vo balance ${migrationChangeDto.voBalance} and pvo balance ${migrationChangeDto.pvoBalance} and lastAllocatedDate ${migrationChangeDto.lastVoAllocationDate}",
       prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
     )
   }
 
-  fun logSyncAdjustmentChange(syncDto: VisitAllocationPrisonerSyncDto, dpsPrisoner: PrisonerDetails): ChangeLog {
+  fun createLogSyncAdjustmentChange(syncDto: VisitAllocationPrisonerSyncDto, dpsPrisoner: PrisonerDetails): ChangeLog {
     LOG.info("Logging sync to change_log table for prisoner ${syncDto.prisonerId}, sync - $syncDto")
     return ChangeLog(
       prisonerId = dpsPrisoner.prisonerId,
@@ -41,10 +42,12 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
       userId = "SYSTEM",
       comment = "synced prisoner ${syncDto.prisonerId}, with adjustment code ${syncDto.adjustmentReasonCode.name}",
       prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
     )
   }
 
-  fun logSyncEventChange(dpsPrisoner: PrisonerDetails, domainEventType: DomainEventType): ChangeLog {
+  fun createLogSyncEventChange(dpsPrisoner: PrisonerDetails, domainEventType: DomainEventType): ChangeLog {
     LOG.info("Logging sync to change_log table for prisoner ${dpsPrisoner.prisonerId}, event - ${domainEventType.value}")
     return ChangeLog(
       prisonerId = dpsPrisoner.prisonerId,
@@ -53,6 +56,8 @@ class ChangeLogService(private val changeLogRepository: ChangeLogRepository) {
       userId = "SYSTEM",
       comment = "synced prisoner ${dpsPrisoner.prisonerId}, with domain event ${domainEventType.value}",
       prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
     )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -9,12 +9,14 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocation
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
 
 @Transactional
 @Service
-class ChangeLogService {
+class ChangeLogService(val changeLogRepository: ChangeLogRepository) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
@@ -59,5 +61,15 @@ class ChangeLogService {
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
     )
+  }
+
+  fun findAllChangeLogsForPrisoner(prisonerId: String): List<ChangeLog> {
+    LOG.info("ChangeLogService - findAllChangeLogsForPrisoner called with prisonerId - $prisonerId")
+    val prisonerChangeLogs = changeLogRepository.findAllByPrisonerId(prisonerId)
+    if (prisonerChangeLogs.isNullOrEmpty()) {
+      throw NotFoundException("No change logs found for prisoner $prisonerId")
+    }
+
+    return prisonerChangeLogs
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -49,7 +49,7 @@ class NomisMigrationService(
     migrateBalance(migrationDto, VisitOrderType.VO, dpsPrisoner)
     migrateBalance(migrationDto, VisitOrderType.PVO, dpsPrisoner)
 
-    dpsPrisoner.changeLogs.add(changeLogService.logMigrationChange(migrationDto, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(changeLogService.createLogMigrationChange(migrationDto, dpsPrisoner))
 
     prisonerDetailsService.updatePrisonerDetails(dpsPrisoner)
     LOG.info("Finished NomisMigrationService - migratePrisoner ${migrationDto.prisonerId} successfully")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -11,16 +11,12 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
-import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
-import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepository
 import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.abs
 
 @Service
 class NomisMigrationService(
-  private val visitOrderRepository: VisitOrderRepository,
-  private val negativeVisitOrderRepository: NegativeVisitOrderRepository,
   private val changeLogService: ChangeLogService,
   private val prisonerDetailsService: PrisonerDetailsService,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -79,7 +79,7 @@ class NomisSyncService(
       dpsPrisoner.lastVoAllocatedDate = syncDto.createdDate
     }
 
-    dpsPrisoner.changeLogs.add(changeLogService.logSyncAdjustmentChange(syncDto, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(changeLogService.createLogSyncAdjustmentChange(syncDto, dpsPrisoner))
 
     prisonerDetailsService.updatePrisonerDetails(prisoner = dpsPrisoner)
   }
@@ -123,7 +123,7 @@ class NomisSyncService(
 
     if (voBalanceChange != 0 || pvoBalanceChange != 0) {
       LOG.info("Balance has changed as a result of sync for prisoner $prisonerId, for domain event ${domainEventType.value}")
-      dpsPrisoner.changeLogs.add(changeLogService.logSyncEventChange(dpsPrisoner, domainEventType))
+      dpsPrisoner.changeLogs.add(changeLogService.createLogSyncEventChange(dpsPrisoner, domainEventType))
     }
 
     prisonerDetailsService.updatePrisonerDetails(prisoner = dpsPrisoner)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
 import java.time.LocalDate
+import kotlin.jvm.optionals.getOrNull
 
 @Transactional
 @Service
@@ -28,7 +29,7 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {
     LOG.info("PrisonerDetailsService - getPrisonerDetails called with prisonerId - $prisonerId")
-    return prisonerDetailsRepository.findByPrisonerId(prisonerId)
+    return prisonerDetailsRepository.findById(prisonerId).getOrNull()
   }
 
   fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {
@@ -38,6 +39,9 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun removePrisonerDetails(prisonerId: String) {
     LOG.info("PrisonerDetailsService - removePrisonerDetails called with prisonerId - $prisonerId")
-    prisonerDetailsRepository.deleteByPrisonerId(prisonerId)
+    val prisoner = prisonerDetailsRepository.findById(prisonerId)
+    if (prisoner.isPresent) {
+      prisonerDetailsRepository.delete(prisoner.get())
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -16,18 +16,28 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
   }
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
-    LOG.info("Prisoner $prisonerId not found, creating new record")
-    val newPrisoner = PrisonerDetails(
-      prisonerId = prisonerId,
-      lastVoAllocatedDate = newLastAllocatedDate,
-      lastPvoAllocatedDate = newLastPvoAllocatedDate,
+    LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId and newLastAllocatedDate - $newLastPvoAllocatedDate")
+    return prisonerDetailsRepository.save(
+      PrisonerDetails(
+        prisonerId = prisonerId,
+        lastVoAllocatedDate = newLastAllocatedDate,
+        lastPvoAllocatedDate = newLastPvoAllocatedDate,
+      ),
     )
-    return prisonerDetailsRepository.save(newPrisoner)
   }
 
-  fun getPrisonerDetails(prisonerId: String): PrisonerDetails? = prisonerDetailsRepository.findByPrisonerId(prisonerId)
+  fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {
+    LOG.info("PrisonerDetailsService - getPrisonerDetails called with prisonerId - $prisonerId")
+    return prisonerDetailsRepository.findByPrisonerId(prisonerId)
+  }
 
-  fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails = prisonerDetailsRepository.save(prisoner)
+  fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {
+    LOG.info("PrisonerDetailsService - updatePrisonerDetails called with new prisoner details - $prisoner")
+    return prisonerDetailsRepository.save(prisoner)
+  }
 
-  fun removePrisonerDetails(prisonerId: String) = prisonerDetailsRepository.deleteByPrisonerId(prisonerId)
+  fun removePrisonerDetails(prisonerId: String) {
+    LOG.info("PrisonerDetailsService - removePrisonerDetails called with prisonerId - $prisonerId")
+    prisonerDetailsRepository.deleteByPrisonerId(prisonerId)
+  }
 }

--- a/src/main/resources/db/migration/V1_11__alter_change_log_table_add_balance_columns.sql
+++ b/src/main/resources/db/migration/V1_11__alter_change_log_table_add_balance_columns.sql
@@ -1,0 +1,16 @@
+BEGIN;
+
+-- Add the columns as NULLABLE (no NOT NULL, no DEFAULT)
+ALTER TABLE change_log ADD COLUMN visit_order_balance integer;
+ALTER TABLE change_log ADD COLUMN privileged_visit_order_balance integer;
+
+-- Back fill existing rows with 0 to avoid needing full migration in dev (prod empty)
+UPDATE change_log
+SET visit_order_balance = 0,
+    privileged_visit_order_balance = 0;
+
+-- Make the columns NOT NULL (since all rows now have a value)
+ALTER TABLE change_log ALTER COLUMN visit_order_balance SET NOT NULL;
+ALTER TABLE change_log ALTER COLUMN privileged_visit_order_balance SET NOT NULL;
+
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -82,7 +82,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -109,7 +109,7 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(any())
 
     verifyNoInteractions(telemetryClientService)
@@ -138,7 +138,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -169,7 +169,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -196,7 +196,7 @@ class NomisSyncServiceTest {
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(any())
 
     verifyNoInteractions(telemetryClientService)
@@ -225,7 +225,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -256,7 +256,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -285,7 +285,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncAdjustmentChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
@@ -321,7 +321,7 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
-    verify(changeLogService, times(1)).logSyncEventChange(any(), any())
+    verify(changeLogService, times(1)).createLogSyncEventChange(any(), any())
     verifyNoInteractions(telemetryClientService)
 
     val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerGetAdjustmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerGetAdjustmentTest.kt
@@ -1,0 +1,171 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpHeaders
+import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.WebTestClient.ResponseSpec
+import uk.gov.justice.digital.hmpps.visitallocationapi.config.ROLE_VISIT_ALLOCATION_API__NOMIS_API
+import uk.gov.justice.digital.hmpps.visitallocationapi.controller.VO_GET_PRISONER_ADJUSTMENT
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerAdjustmentRequestDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerAdjustmentResponseDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper.callGet
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import java.time.LocalDate
+
+@DisplayName("NomisController get prisoner adjustment tests - $VO_GET_PRISONER_ADJUSTMENT")
+class NomisControllerGetAdjustmentTest : IntegrationTestBase() {
+
+  companion object {
+    const val PRISONER_ID = "AA123456"
+  }
+
+  @Test
+  fun `when a request comes in to get a prisoners adjustment, then DPS service successfully returns the information`() {
+    // Given
+    val prisoner = entityHelper.createPrisonerDetails(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+    entityHelper.createChangeLog(
+      ChangeLog(
+        changeType = ChangeLogType.SYNC,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Synced prisoner",
+        prisonerId = prisoner.prisonerId,
+        visitOrderBalance = 5,
+        privilegedVisitOrderBalance = 2,
+        prisoner = prisoner,
+      ),
+    )
+
+    val changeLogId = entityHelper.createChangeLog(
+      ChangeLog(
+        changeType = ChangeLogType.SYNC,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Synced prisoner",
+        prisonerId = prisoner.prisonerId,
+        visitOrderBalance = 7,
+        privilegedVisitOrderBalance = 3,
+        prisoner = prisoner,
+      ),
+    ).id
+
+    val adjustmentRequestDto = createAdjustmentRequest(PRISONER_ID, changeLogId)
+
+    // When
+    val responseSpec = callVisitAllocationGetAdjustmentEndpoint(webTestClient, adjustmentRequestDto, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val result = responseSpec.expectStatus().isOk.expectBody()
+    val adjustmentResponseDto = getVisitAdjustmentResponseDto(result)
+    assertAdjustmentResponse(adjustmentResponseDto = adjustmentResponseDto, expectedVoBalance = 5, expectedVoChange = 2, expectedPvoBalance = 2, expectedPvoChange = 1)
+  }
+
+  @Test
+  fun `when a request comes in to get a prisoners adjustment, and only 1 entry exists in change logs, then DPS service successfully returns the information`() {
+    // Given
+    val prisoner = entityHelper.createPrisonerDetails(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    val changeLogId = entityHelper.createChangeLog(
+      ChangeLog(
+        changeType = ChangeLogType.SYNC,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Synced prisoner",
+        prisonerId = prisoner.prisonerId,
+        visitOrderBalance = 7,
+        privilegedVisitOrderBalance = 3,
+        prisoner = prisoner,
+      ),
+    ).id
+
+    val adjustmentRequestDto = createAdjustmentRequest(PRISONER_ID, changeLogId)
+
+    // When
+    val responseSpec = callVisitAllocationGetAdjustmentEndpoint(webTestClient, adjustmentRequestDto, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
+
+    // Then
+    responseSpec.expectStatus().isOk
+    val result = responseSpec.expectStatus().isOk.expectBody()
+    val adjustmentResponseDto = getVisitAdjustmentResponseDto(result)
+    assertAdjustmentResponse(adjustmentResponseDto = adjustmentResponseDto, expectedVoBalance = 0, expectedVoChange = 7, expectedPvoBalance = 0, expectedPvoChange = 3)
+  }
+
+  @Test
+  fun `when a request comes in to get a prisoners adjustment, but it can't be found, then DPS service returns 404 NOT_FOUND`() {
+    // Given
+    val prisoner = entityHelper.createPrisonerDetails(PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null))
+
+    val adjustmentRequestDto = createAdjustmentRequest(PRISONER_ID, 123L)
+
+    // When
+    val responseSpec = callVisitAllocationGetAdjustmentEndpoint(webTestClient, adjustmentRequestDto, setAuthorisation(roles = listOf(ROLE_VISIT_ALLOCATION_API__NOMIS_API)))
+
+    // Then
+    responseSpec.expectStatus().isNotFound
+  }
+
+  @Test
+  fun `access forbidden when no role`() {
+    // Given
+    val incorrectAuthHeaders = setAuthorisation(roles = listOf())
+    val adjustmentRequestDto = createAdjustmentRequest("AA123456", 123L)
+
+    // When
+    val responseSpec = callVisitAllocationGetAdjustmentEndpoint(webTestClient, adjustmentRequestDto, incorrectAuthHeaders)
+
+    // Then
+    responseSpec.expectStatus().isForbidden
+  }
+
+  @Test
+  fun `unauthorised when no token`() {
+    // Given no auth token
+
+    // When
+    val responseSpec = webTestClient.post().uri(getNomisPrisonerAdjustmentUrl(PRISONER_ID, "123L")).exchange()
+
+    // Then
+    responseSpec.expectStatus().isUnauthorized
+  }
+
+  private fun callVisitAllocationGetAdjustmentEndpoint(
+    webTestClient: WebTestClient,
+    dto: VisitAllocationPrisonerAdjustmentRequestDto,
+    authHttpHeaders: (HttpHeaders) -> Unit,
+  ): ResponseSpec = callGet(
+    webTestClient,
+    getNomisPrisonerAdjustmentUrl(dto.prisonerId, dto.changeLogId.toString()),
+    authHttpHeaders,
+  )
+
+  private fun createAdjustmentRequest(
+    prisonerId: String,
+    changeLogId: Long,
+  ): VisitAllocationPrisonerAdjustmentRequestDto = VisitAllocationPrisonerAdjustmentRequestDto(
+    prisonerId,
+    changeLogId,
+  )
+
+  private fun getNomisPrisonerAdjustmentUrl(prisonerId: String, changeLogId: String): String = VO_GET_PRISONER_ADJUSTMENT
+    .replace("{prisonerId}", prisonerId)
+    .replace("{adjustmentId}", changeLogId)
+
+  private fun assertAdjustmentResponse(adjustmentResponseDto: VisitAllocationPrisonerAdjustmentResponseDto, expectedVoBalance: Int, expectedVoChange: Int, expectedPvoBalance: Int, expectedPvoChange: Int) {
+    assertThat(adjustmentResponseDto.voBalance).isEqualTo(expectedVoBalance)
+    assertThat(adjustmentResponseDto.changeToVoBalance).isEqualTo(expectedVoChange)
+
+    assertThat(adjustmentResponseDto.pvoBalance).isEqualTo(expectedPvoBalance)
+    assertThat(adjustmentResponseDto.changeToPvoBalance).isEqualTo(expectedPvoChange)
+  }
+
+  private fun getVisitAdjustmentResponseDto(returnResult: WebTestClient.BodyContentSpec): VisitAllocationPrisonerAdjustmentResponseDto = objectMapper.readValue(
+    returnResult.returnResult().responseBody,
+    VisitAllocationPrisonerAdjustmentResponseDto::class.java,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerSyncTest.kt
@@ -450,7 +450,7 @@ class NomisControllerSyncTest : IntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE && it.type == VisitOrderType.VO }.size).isEqualTo(expectedVoCount)
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE && it.type == VisitOrderType.PVO }.size).isEqualTo(expectedPvoCount)
 
-    val prisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerSyncDto.prisonerId)!!
+    val prisonerDetails = prisonerDetailsRepository.findById(prisonerSyncDto.prisonerId).get()
     assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(prisonerSyncDto.createdDate)
 
     val expectedNegativeVisitOrderTotal = expectedNegativeVoCount + expectedNegativePvoCount

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -61,7 +61,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(2)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -96,7 +96,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(2)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -102,11 +102,11 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(3)
 
-    val movedFromPrisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId = movedFromPrisonerId)!!
+    val movedFromPrisonerDetails = prisonerDetailsRepository.findById(movedFromPrisonerId).get()
     assertThat(movedFromPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
     assertThat(movedFromPrisonerDetails.lastPvoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
 
-    val movedToPrisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId = movedToPrisonerId)!!
+    val movedToPrisonerDetails = prisonerDetailsRepository.findById(movedToPrisonerId).get()
     assertThat(movedToPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
     assertThat(movedToPrisonerDetails.lastPvoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
@@ -178,7 +178,7 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(5)
 
-    val prisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
+    val prisonerDetails = prisonerDetailsRepository.findById(prisonerId).get()
     assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now())
     assertThat(prisonerDetails.lastPvoAllocatedDate).isNull()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerConvictionStatusChangedTest.kt
@@ -52,7 +52,7 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -172,7 +172,7 @@ class DomainEventsPrisonerConvictionStatusChangedTest : EventsIntegrationTestBas
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
@@ -53,7 +53,7 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerRemoved(any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -147,7 +147,7 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerRemoved(any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
@@ -144,7 +144,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(5)
 
-    val prisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
+    val prisonerDetails = prisonerDetailsRepository.findById(prisonerId).get()
     assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now())
     assertThat(prisonerDetails.lastPvoAllocatedDate).isNull()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
@@ -52,7 +52,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()
@@ -138,7 +138,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
@@ -53,7 +53,7 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
     await untilAsserted { verify(nomisSyncService, times(1)).syncPrisonerBalanceFromEventChange(any(), any()) }
-    await untilAsserted { verify(changeLogService, times(1)).logSyncEventChange(any(), any()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogSyncEventChange(any(), any()) }
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
 
     val visitOrders = visitOrderRepository.findAll()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReleasedTest.kt
@@ -144,7 +144,7 @@ class DomainEventsPrisonerReleasedTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(0)
 
-    val prisonerDetails = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
+    val prisonerDetails = prisonerDetailsRepository.findById(prisonerId).get()
     assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now())
     assertThat(prisonerDetails.lastPvoAllocatedDate).isNull()
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
@@ -131,6 +131,7 @@ abstract class EventsIntegrationTestBase {
   @MockitoSpyBean
   lateinit var changeLogService: ChangeLogService
 
+  @AfterEach
   @BeforeEach
   fun cleanQueue() {
     purgeQueue(domainEventsSqsClient, domainEventsQueueUrl)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
@@ -14,29 +15,26 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitO
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderPrisonRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepository
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import java.time.LocalDateTime
 
-@Component
 @Transactional
+@Component
 class EntityHelper(
   val visitOrderPrisonRepository: VisitOrderPrisonRepository,
   val visitOrderRepository: VisitOrderRepository,
   val negativeVisitOrderRepository: NegativeVisitOrderRepository,
   val changeLogRepository: ChangeLogRepository,
   private val prisonerDetailsRepository: PrisonerDetailsRepository,
-  private val prisonerDetailsService: PrisonerDetailsService,
 ) {
 
-  @Transactional
   fun savePrison(visitOrderPrison: VisitOrderPrison) {
     visitOrderPrisonRepository.saveAndFlush(visitOrderPrison)
   }
 
-  @Transactional
   fun createPrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails = prisonerDetailsRepository.saveAndFlush(prisoner)
 
-  @Transactional
+  fun createChangeLog(changeLog: ChangeLog): ChangeLog = changeLogRepository.save(changeLog)
+
   fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, status: VisitOrderStatus, createdDateTime: LocalDateTime, amountToCreate: Int) {
     val prisoner = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
 
@@ -57,7 +55,6 @@ class EntityHelper(
     prisonerDetailsRepository.saveAndFlush(prisoner)
   }
 
-  @Transactional
   fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: VisitOrderType, amountToCreate: Int) {
     val prisoner = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
 
@@ -77,7 +74,6 @@ class EntityHelper(
     prisonerDetailsRepository.saveAndFlush(prisoner)
   }
 
-  @Transactional
   fun deleteAll() {
     visitOrderPrisonRepository.deleteAll()
     visitOrderPrisonRepository.flush()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/helper/EntityHelper.kt
@@ -36,7 +36,7 @@ class EntityHelper(
   fun createChangeLog(changeLog: ChangeLog): ChangeLog = changeLogRepository.save(changeLog)
 
   fun createAndSaveVisitOrders(prisonerId: String, visitOrderType: VisitOrderType, status: VisitOrderStatus, createdDateTime: LocalDateTime, amountToCreate: Int) {
-    val prisoner = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
+    val prisoner = prisonerDetailsRepository.findById(prisonerId).get()
 
     val visitOrders = mutableListOf<VisitOrder>()
     repeat(amountToCreate) {
@@ -56,7 +56,7 @@ class EntityHelper(
   }
 
   fun createAndSaveNegativeVisitOrders(prisonerId: String, negativeVoType: VisitOrderType, amountToCreate: Int) {
-    val prisoner = prisonerDetailsRepository.findByPrisonerId(prisonerId)!!
+    val prisoner = prisonerDetailsRepository.findById(prisonerId).get()
 
     val negativeVisitOrders = mutableListOf<NegativeVisitOrder>()
     repeat(amountToCreate) {


### PR DESCRIPTION
## What does this PR do?
This PR aims to capture the prisoners balance at every point it changes via logging in the change_log table.

It also adds a new endpoint to the NOMIS Controller, which allows NOMIS to get a prisoners adjustment by providing the prisoner ID and adjustment ID (/visits/allocation/prisoner/{prisonerId}/adjustments/{adjustmentId}

This new endpoint will be used in near future when we begin publishing events for each prisoner that has a balance change, allowing NOMIS to stay in sync (2-way sync, DPS -> NOMIS).