### PR TITLE
Move prisoner processing into separate class with managed transaction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/ChangeLogType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/ChangeLogType.kt
@@ -5,4 +5,5 @@ enum class ChangeLogType {
   MIGRATION,
   SYNC,
   PRISONER_REMOVED,
+  BATCH_PROCESS,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
@@ -57,4 +57,42 @@ data class PrisonerDetails(
       )
   }
     .minus(this.negativeVisitOrders.count { it.type == VisitOrderType.PVO && it.status == NegativeVisitOrderStatus.USED })
+
+  fun deepCopy(): PrisonerDetails {
+    val copy = PrisonerDetails(
+      prisonerId = this.prisonerId,
+      lastVoAllocatedDate = this.lastVoAllocatedDate,
+      lastPvoAllocatedDate = this.lastPvoAllocatedDate,
+    )
+
+    // Deep copy visit orders
+    copy.visitOrders = this.visitOrders.map {
+      VisitOrder(
+        id = it.id,
+        type = it.type,
+        createdTimestamp = it.createdTimestamp,
+        expiryDate = it.expiryDate,
+        prisonerId = it.prisonerId,
+        status = it.status,
+        prisoner = copy, // Point to the new copy, not the original
+      )
+    }.toMutableList()
+
+    // Deep copy negative visit orders
+    copy.negativeVisitOrders = this.negativeVisitOrders.map {
+      NegativeVisitOrder(
+        id = it.id,
+        type = it.type,
+        status = it.status,
+        createdTimestamp = it.createdTimestamp,
+        repaidDate = it.repaidDate,
+        prisonerId = it.prisonerId,
+        prisoner = copy,
+      )
+    }.toMutableList()
+
+    // !! Don't copy changeLogs as it's lazy and might not be loaded. Also, not needed for deep copy purposes.
+
+    return copy
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrderAllocationPrisonJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrderAllocationPrisonJob.kt
@@ -33,7 +33,7 @@ class VisitOrderAllocationPrisonJob(
   val processedPrisoners: Int? = null,
 
   @Column(nullable = false)
-  val failedPrisoners: Int? = null,
+  val failedOrSkippedPrisoners: Int? = null,
 
   @Column
   val endTimestamp: LocalDateTime? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderAllocationPrisonJobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderAllocationPrisonJobRepository.kt
@@ -52,7 +52,7 @@ interface VisitOrderAllocationPrisonJobRepository : JpaRepository<VisitOrderAllo
         v.endTimestamp = :endTimestamp, 
         v.convictedPrisoners = :totalPrisoners,
         v.processedPrisoners = :processedPrisoners,
-        v.failedPrisoners = :failedPrisoners
+        v.failedOrSkippedPrisoners = :failedOrSkippedPrisoners
         WHERE v.prisonCode = :prisonCode 
         AND v.allocationJobReference = :allocationJobReference
     """,
@@ -63,6 +63,6 @@ interface VisitOrderAllocationPrisonJobRepository : JpaRepository<VisitOrderAllo
     endTimestamp: LocalDateTime,
     totalPrisoners: Int,
     processedPrisoners: Int,
-    failedPrisoners: Int,
+    failedOrSkippedPrisoners: Int,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -28,7 +28,7 @@ class AllocationService(
     val allPrisoners = getConvictedPrisonersForPrison(jobReference = jobReference, prisonId = prisonId)
     val allIncentiveLevels = getIncentiveLevelsForPrison(jobReference = jobReference, prisonId = prisonId)
     var totalConvictedPrisonersProcessed = 0
-    var totalConvictedPrisonersFailed = 0
+    var totalConvictedPrisonersFailedOrSkipped = 0
 
     for (prisoner in allPrisoners) {
       val changeLog = processPrisonerService.processPrisoner(
@@ -41,7 +41,7 @@ class AllocationService(
         totalConvictedPrisonersProcessed++
         // TODO: Publish event using changeLog captured above
       } else {
-        totalConvictedPrisonersFailed++
+        totalConvictedPrisonersFailedOrSkipped++
       }
     }
 
@@ -50,7 +50,7 @@ class AllocationService(
       prisonCode = prisonId,
       totalConvictedPrisoners = allPrisoners.size,
       totalPrisonersProcessed = totalConvictedPrisonersProcessed,
-      totalPrisonersFailed = totalConvictedPrisonersFailed,
+      totalPrisonersFailedOrSkipped = totalConvictedPrisonersFailedOrSkipped,
     )
 
     LOG.info("Finished AllocationService - processPrisonAllocation with prisonCode: $prisonId, total records processed : ${allPrisoners.size}")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -2,20 +2,12 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service
 
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
-import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Transactional
 @Service
@@ -23,9 +15,7 @@ class AllocationService(
   private val prisonerSearchClient: PrisonerSearchClient,
   private val incentivesClient: IncentivesClient,
   private val prisonService: PrisonService,
-  private val prisonerDetailsService: PrisonerDetailsService,
-  private val prisonerRetryService: PrisonerRetryService,
-  @Value("\${max.visit-orders:26}") val maxAccumulatedVisitOrders: Int,
+  private val processPrisonerService: ProcessPrisonerService,
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -38,31 +28,15 @@ class AllocationService(
     val allPrisoners = getConvictedPrisonersForPrison(jobReference = jobReference, prisonId = prisonId)
     val allIncentiveLevels = getIncentiveLevelsForPrison(jobReference = jobReference, prisonId = prisonId)
     var totalConvictedPrisonersProcessed = 0
-    var totalConvictedPrisonersFailed = 0
 
+    // TODO: When ChangeLog is implemented and returned, if null -> totalConvictedPrisonersFailed++ else -> totalConvictedPrisonersProcessed++
     for (prisoner in allPrisoners) {
-      try {
-        // Get prisoner on DPS (or create if they're new).
-        val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisoner.prisonerId)
-          ?: prisonerDetailsService.createPrisonerDetails(prisoner.prisonerId, LocalDate.now().minusDays(14), null)
-
-        processPrisonerAllocation(dpsPrisonerDetails, allIncentiveLevels)
-        processPrisonerAccumulation(dpsPrisonerDetails)
-        processPrisonerExpiration(dpsPrisonerDetails)
-
-        prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
-
-        totalConvictedPrisonersProcessed++
-      } catch (e: Exception) {
-        // ignore the prisoner and send it to an SQS queue to ensure the whole process does not stop
-        LOG.error("Error processing prisoner - ${prisoner.prisonerId}, putting ${prisoner.prisonerId} on prisoner retry queue", e)
-        totalConvictedPrisonersFailed++
-
-        prisonerRetryService.sendMessageToPrisonerRetryQueue(
-          jobReference = jobReference,
-          prisonerId = prisoner.prisonerId,
-        )
-      }
+      processPrisonerService.processPrisoner(
+        prisonerId = prisoner.prisonerId,
+        jobReference = jobReference,
+        allPrisonIncentiveAmounts = allIncentiveLevels,
+      )
+      totalConvictedPrisonersProcessed++
     }
 
     prisonService.setVisitOrderAllocationPrisonJobEndTimeAndStats(
@@ -70,135 +44,10 @@ class AllocationService(
       prisonCode = prisonId,
       totalConvictedPrisoners = allPrisoners.size,
       totalPrisonersProcessed = totalConvictedPrisonersProcessed,
-      totalPrisonersFailed = totalConvictedPrisonersFailed,
+      totalPrisonersFailed = allPrisoners.size - totalConvictedPrisonersProcessed,
     )
 
     LOG.info("Finished AllocationService - processPrisonAllocation with prisonCode: $prisonId, total records processed : ${allPrisoners.size}")
-  }
-
-  fun processPrisonerAllocation(dpsPrisoner: PrisonerDetails, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>? = null) {
-    LOG.info("Entered AllocationService - processPrisonerAllocation with prisonerId ${dpsPrisoner.prisonerId}")
-
-    val prisonerPrisonId = prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId).prisonId
-    val prisonerIncentive = incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)
-
-    val prisonIncentiveAmounts = allPrisonIncentiveAmounts?.firstOrNull { it.levelCode == prisonerIncentive.iepCode }
-      ?: incentivesClient.getPrisonIncentiveLevelByLevelCode(prisonerPrisonId, prisonerIncentive.iepCode)
-
-    val visitOrders = mutableListOf<VisitOrder>()
-    visitOrders.addAll(generateVos(dpsPrisoner, prisonIncentiveAmounts))
-    visitOrders.addAll(generatePVos(dpsPrisoner, prisonIncentiveAmounts))
-
-    // Capture the VO / PVOs created, to see if we need to update allocation dates.
-    updateLastAllocatedDates(dpsPrisoner, visitOrders)
-
-    dpsPrisoner.visitOrders.addAll(visitOrders)
-
-    LOG.info("Successfully generated ${visitOrders.size} visit orders for prisoner ${dpsPrisoner.prisonerId}: " + "${visitOrders.count { it.type == VisitOrderType.PVO }} PVOs and ${visitOrders.count { it.type == VisitOrderType.VO }} VOs")
-  }
-
-  private fun processPrisonerAccumulation(dpsPrisoner: PrisonerDetails) {
-    LOG.info("Entered AllocationService - processPrisonerAccumulation with prisonerId: ${dpsPrisoner.prisonerId}")
-
-    dpsPrisoner.visitOrders.filter { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.AVAILABLE && it.createdTimestamp.isBefore(LocalDateTime.now().minusDays(28)) }.forEach { it.status = VisitOrderStatus.ACCUMULATED }
-    LOG.info("Completed accumulation for ${dpsPrisoner.prisonerId}")
-  }
-
-  private fun processPrisonerExpiration(dpsPrisoner: PrisonerDetails) {
-    LOG.info("Entered AllocationService - processPrisonerExpiration with prisonerId: ${dpsPrisoner.prisonerId}")
-
-    // Expire all VOs over the maximum accumulation cap.
-    val currentAccumulatedVoCount = dpsPrisoner.visitOrders.count { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.ACCUMULATED }
-    if (currentAccumulatedVoCount > maxAccumulatedVisitOrders) {
-      val amountToExpire = currentAccumulatedVoCount - maxAccumulatedVisitOrders
-      LOG.info("prisoner ${dpsPrisoner.prisonerId} has $currentAccumulatedVoCount VOs. This is more than maximum allowed accumulated VOs $maxAccumulatedVisitOrders. Expiring $amountToExpire VOs")
-
-      dpsPrisoner.visitOrders
-        .filter { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.ACCUMULATED }
-        .sortedBy { it.createdTimestamp }
-        .take(amountToExpire)
-        .forEach {
-          it.status = VisitOrderStatus.EXPIRED
-          it.expiryDate = LocalDate.now()
-        }
-    }
-
-    // Expire all PVOs older than 28 days.
-    dpsPrisoner.visitOrders
-      .filter {
-        it.type == VisitOrderType.PVO &&
-          it.status == VisitOrderStatus.AVAILABLE &&
-          it.createdTimestamp.isBefore(LocalDateTime.now().minusDays(28))
-      }
-      .forEach {
-        it.status = VisitOrderStatus.EXPIRED
-        it.expiryDate = LocalDate.now()
-      }
-
-    LOG.info("Completed expiry for prisoner ${dpsPrisoner.prisonerId}")
-  }
-
-  private fun updateLastAllocatedDates(dpsPrisoner: PrisonerDetails, visitOrders: MutableList<VisitOrder>) {
-    // Only update the lastVoAllocatedDate and lastPvoAllocatedDate if VOs and PVOs have been generated.
-    if (visitOrders.any { it.type == VisitOrderType.VO }) {
-      dpsPrisoner.lastVoAllocatedDate = LocalDate.now()
-    }
-    if (visitOrders.any { it.type == VisitOrderType.PVO }) {
-      dpsPrisoner.lastPvoAllocatedDate = LocalDate.now()
-    }
-  }
-
-  private fun createVisitOrder(prisoner: PrisonerDetails, type: VisitOrderType): VisitOrder = VisitOrder(
-    prisonerId = prisoner.prisonerId,
-    type = type,
-    status = VisitOrderStatus.AVAILABLE,
-    createdTimestamp = LocalDateTime.now(),
-    expiryDate = null,
-    prisoner = prisoner,
-  )
-
-  private fun isDueVO(prisoner: PrisonerDetails): Boolean = prisoner.lastVoAllocatedDate <= LocalDate.now().minusDays(14)
-
-  private fun isDuePVO(prisoner: PrisonerDetails): Boolean {
-    val lastPVODate = prisoner.lastPvoAllocatedDate
-
-    // If they haven't been given a PVO before, we wait until their VO due date to allocate it, to align the dates.
-    if (lastPVODate == null) {
-      return isDueVO(prisoner)
-    }
-
-    return lastPVODate <= LocalDate.now().minusDays(28)
-  }
-
-  private fun generateVos(prisoner: PrisonerDetails, prisonIncentivesForPrisonerLevel: PrisonIncentiveAmountsDto): List<VisitOrder> {
-    val visitOrders = mutableListOf<VisitOrder>()
-    if (isDueVO(prisoner)) {
-      val negativeVoCount = prisoner.negativeVisitOrders.count { it.type == VisitOrderType.VO && it.status == NegativeVisitOrderStatus.USED }
-      if (negativeVoCount > 0) {
-        handleNegativeBalanceRepayment(prisonIncentivesForPrisonerLevel.visitOrders, negativeVoCount, prisoner, VisitOrderType.VO, visitOrders)
-      } else {
-        repeat(prisonIncentivesForPrisonerLevel.visitOrders) {
-          visitOrders.add(createVisitOrder(prisoner, VisitOrderType.VO))
-        }
-      }
-    }
-    return visitOrders
-  }
-
-  private fun generatePVos(prisoner: PrisonerDetails, prisonIncentivesForPrisonerLevel: PrisonIncentiveAmountsDto): List<VisitOrder> {
-    val visitOrders = mutableListOf<VisitOrder>()
-
-    if (prisonIncentivesForPrisonerLevel.privilegedVisitOrders != 0 && isDuePVO(prisoner)) {
-      val negativePvoCount = prisoner.negativeVisitOrders.count { it.type == VisitOrderType.PVO && it.status == NegativeVisitOrderStatus.USED }
-      if (negativePvoCount > 0) {
-        handleNegativeBalanceRepayment(prisonIncentivesForPrisonerLevel.privilegedVisitOrders, negativePvoCount, prisoner, VisitOrderType.PVO, visitOrders)
-      } else {
-        repeat(prisonIncentivesForPrisonerLevel.privilegedVisitOrders) {
-          visitOrders.add(createVisitOrder(prisoner, VisitOrderType.PVO))
-        }
-      }
-    }
-    return visitOrders
   }
 
   private fun getConvictedPrisonersForPrison(jobReference: String, prisonId: String): List<PrisonerDto> {
@@ -225,33 +74,5 @@ class AllocationService(
     }
 
     return incentiveLevelsForPrison
-  }
-
-  private fun handleNegativeBalanceRepayment(incentiveAmount: Int, negativeBalance: Int, prisoner: PrisonerDetails, type: VisitOrderType, visitOrders: MutableList<VisitOrder>) {
-    if (incentiveAmount < negativeBalance) {
-      // If the incentive amount doesn't fully cover debt, then only repay what is possible.
-      prisoner.negativeVisitOrders
-        .filter { it.type == type && it.status == NegativeVisitOrderStatus.USED }
-        .sortedBy { it.createdTimestamp }
-        .take(incentiveAmount)
-        .forEach {
-          it.status = NegativeVisitOrderStatus.REPAID
-          it.repaidDate = LocalDate.now()
-        }
-    } else {
-      // If the incentive amount pushes the balance positive, repay all debt and generate the required amount of positive VO / PVOs.
-      prisoner.negativeVisitOrders
-        .filter { it.type == type && it.status == NegativeVisitOrderStatus.USED }
-        .forEach {
-          it.status = NegativeVisitOrderStatus.REPAID
-          it.repaidDate = LocalDate.now()
-        }
-
-      val visitOrdersToCreate = incentiveAmount - negativeBalance
-
-      repeat(visitOrdersToCreate) {
-        visitOrders.add(createVisitOrder(prisoner, type))
-      }
-    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -63,6 +63,20 @@ class ChangeLogService(val changeLogRepository: ChangeLogRepository) {
     )
   }
 
+  fun createLogBatchProcess(dpsPrisoner: PrisonerDetails): ChangeLog {
+    LOG.info("Logging sync to change_log table for prisoner ${dpsPrisoner.prisonerId} - createLogBatchProcess complete")
+    return ChangeLog(
+      prisonerId = dpsPrisoner.prisonerId,
+      changeType = ChangeLogType.BATCH_PROCESS,
+      changeSource = ChangeLogSource.SYSTEM,
+      userId = "SYSTEM",
+      comment = "batch process run for prisoner ${dpsPrisoner.prisonerId}",
+      prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    )
+  }
+
   fun findAllChangeLogsForPrisoner(prisonerId: String): List<ChangeLog> {
     LOG.info("ChangeLogService - findAllChangeLogsForPrisoner called with prisonerId - $prisonerId")
     val prisonerChangeLogs = changeLogRepository.findAllByPrisonerId(prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonService.kt
@@ -55,8 +55,8 @@ class PrisonService(
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  fun setVisitOrderAllocationPrisonJobEndTimeAndStats(jobReference: String, prisonCode: String, totalConvictedPrisoners: Int, totalPrisonersProcessed: Int, totalPrisonersFailed: Int) {
-    visitOrderAllocationPrisonJobRepository.updateEndTimestampAndStats(allocationJobReference = jobReference, prisonCode = prisonCode, LocalDateTime.now(), totalPrisoners = totalConvictedPrisoners, processedPrisoners = totalPrisonersProcessed, failedPrisoners = totalPrisonersFailed)
+  fun setVisitOrderAllocationPrisonJobEndTimeAndStats(jobReference: String, prisonCode: String, totalConvictedPrisoners: Int, totalPrisonersProcessed: Int, totalPrisonersFailedOrSkipped: Int) {
+    visitOrderAllocationPrisonJobRepository.updateEndTimestampAndStats(allocationJobReference = jobReference, prisonCode = prisonCode, LocalDateTime.now(), totalPrisoners = totalConvictedPrisoners, processedPrisoners = totalPrisonersProcessed, failedOrSkippedPrisoners = totalPrisonersFailedOrSkipped)
   }
 
   private fun auditOrderAllocationJob(totalActivePrisons: Int): VisitOrderAllocationJob {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
@@ -36,7 +36,8 @@ class PrisonerRetryService(
     log.info("handle prisoner - $prisonerId on retry queue")
     val prisoner = prisonerSearchClient.getPrisonerById(prisonerId)
     val allIncentiveLevels = getIncentiveLevelsForPrison(prisonId = prisoner.prisonId)
-    processPrisonerService.processPrisoner(prisonerId, jobReference, allIncentiveLevels, fromRetryQueue = true)
+    val changeLog = processPrisonerService.processPrisoner(prisonerId, jobReference, allIncentiveLevels, fromRetryQueue = true)
+    // TODO: Publish event using changeLog captured above
   }
 
   private fun getIncentiveLevelsForPrison(prisonId: String): List<PrisonIncentiveAmountsDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
@@ -4,18 +4,19 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.AllocationService.Companion.LOG
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs.VisitAllocationPrisonerRetrySqsService
-import java.time.LocalDate
 
 @Service
 class PrisonerRetryService(
   private val visitAllocationPrisonerRetrySqsService: VisitAllocationPrisonerRetrySqsService,
+  private val incentivesClient: IncentivesClient,
+  private val prisonerSearchClient: PrisonerSearchClient,
   @Lazy
-  private val allocationService: AllocationService,
-  @Lazy
-  private val prisonerDetailsService: PrisonerDetailsService,
+  private val processPrisonerService: ProcessPrisonerService,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -31,15 +32,22 @@ class PrisonerRetryService(
     }
   }
 
-  @Transactional
-  fun handlePrisonerRetry(prisonerId: String) {
+  fun handlePrisonerRetry(jobReference: String, prisonerId: String) {
     log.info("handle prisoner - $prisonerId on retry queue")
+    val prisoner = prisonerSearchClient.getPrisonerById(prisonerId)
+    val allIncentiveLevels = getIncentiveLevelsForPrison(prisonId = prisoner.prisonId)
+    processPrisonerService.processPrisoner(prisonerId, jobReference, allIncentiveLevels, fromRetryQueue = true)
+  }
 
-    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisonerId)
-      ?: prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+  private fun getIncentiveLevelsForPrison(prisonId: String): List<PrisonIncentiveAmountsDto> {
+    val incentiveLevelsForPrison = try {
+      incentivesClient.getPrisonIncentiveLevels(prisonId)
+    } catch (e: Exception) {
+      val failureMessage = "failed to get incentive levels by prisonId - $prisonId in retry queue consumer"
+      LOG.error(failureMessage, e)
+      throw e
+    }
 
-    allocationService.processPrisonerAllocation(dpsPrisonerDetails)
-
-    prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
+    return incentiveLevelsForPrison
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -1,0 +1,214 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+@Service
+class ProcessPrisonerService(
+  private val prisonerSearchClient: PrisonerSearchClient,
+  private val incentivesClient: IncentivesClient,
+  private val prisonerDetailsService: PrisonerDetailsService,
+  private val prisonerRetryService: PrisonerRetryService,
+  @Value("\${max.visit-orders:26}") val maxAccumulatedVisitOrders: Int,
+) {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun processPrisoner(prisonerId: String, jobReference: String, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>, fromRetryQueue: Boolean? = false) {
+    LOG.info("Entered ProcessPrisonerService - processPrisoner for prisoner - $prisonerId")
+
+    try {
+      // Get prisoner on DPS (or create if they're new).
+      val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisonerId)
+        ?: prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+
+      processPrisonerAllocation(dpsPrisonerDetails, allPrisonIncentiveAmounts)
+      processPrisonerAccumulation(dpsPrisonerDetails)
+      processPrisonerExpiration(dpsPrisonerDetails)
+
+      prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
+    } catch (e: Exception) {
+      // When a prisoner is processed from the retry queue, we don't want to add them back if an exception happens. Instead
+      // they should go onto the DLQ.
+      if (fromRetryQueue == false) {
+        LOG.error("Error processing prisoner - $prisonerId, putting $prisonerId on prisoner retry queue", e)
+        prisonerRetryService.sendMessageToPrisonerRetryQueue(
+          jobReference = jobReference,
+          prisonerId = prisonerId,
+        )
+      } else {
+        LOG.error("Error processing prisoner - $prisonerId from retry queue", e)
+        throw e
+      }
+    }
+  }
+
+  private fun processPrisonerAllocation(dpsPrisoner: PrisonerDetails, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>) {
+    LOG.info("Entered ProcessPrisonerService - processPrisonerAllocation with prisonerId ${dpsPrisoner.prisonerId}")
+
+    val prisonerPrisonId = prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId).prisonId
+    val prisonerIncentive = incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)
+
+    val prisonIncentiveAmounts = allPrisonIncentiveAmounts.firstOrNull { it.levelCode == prisonerIncentive.iepCode }
+      ?: incentivesClient.getPrisonIncentiveLevelByLevelCode(prisonerPrisonId, prisonerIncentive.iepCode)
+
+    val visitOrders = mutableListOf<VisitOrder>()
+    visitOrders.addAll(generateVos(dpsPrisoner, prisonIncentiveAmounts))
+    visitOrders.addAll(generatePVos(dpsPrisoner, prisonIncentiveAmounts))
+
+    // Capture the VO / PVOs created, to see if we need to update allocation dates.
+    updateLastAllocatedDates(dpsPrisoner, visitOrders)
+
+    dpsPrisoner.visitOrders.addAll(visitOrders)
+
+    LOG.info("Successfully generated ${visitOrders.size} visit orders for prisoner ${dpsPrisoner.prisonerId}: " + "${visitOrders.count { it.type == VisitOrderType.PVO }} PVOs and ${visitOrders.count { it.type == VisitOrderType.VO }} VOs")
+  }
+
+  private fun processPrisonerAccumulation(dpsPrisoner: PrisonerDetails) {
+    LOG.info("Entered ProcessPrisonerService - processPrisonerAccumulation with prisonerId: ${dpsPrisoner.prisonerId}")
+
+    dpsPrisoner.visitOrders.filter { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.AVAILABLE && it.createdTimestamp.isBefore(LocalDateTime.now().minusDays(28)) }.forEach { it.status = VisitOrderStatus.ACCUMULATED }
+    LOG.info("Completed accumulation for ${dpsPrisoner.prisonerId}")
+  }
+
+  private fun processPrisonerExpiration(dpsPrisoner: PrisonerDetails) {
+    LOG.info("Entered ProcessPrisonerService - processPrisonerExpiration with prisonerId: ${dpsPrisoner.prisonerId}")
+
+    // Expire all VOs over the maximum accumulation cap.
+    val currentAccumulatedVoCount = dpsPrisoner.visitOrders.count { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.ACCUMULATED }
+    if (currentAccumulatedVoCount > maxAccumulatedVisitOrders) {
+      val amountToExpire = currentAccumulatedVoCount - maxAccumulatedVisitOrders
+      LOG.info("prisoner ${dpsPrisoner.prisonerId} has $currentAccumulatedVoCount VOs. This is more than maximum allowed accumulated VOs $maxAccumulatedVisitOrders. Expiring $amountToExpire VOs")
+
+      dpsPrisoner.visitOrders
+        .filter { it.type == VisitOrderType.VO && it.status == VisitOrderStatus.ACCUMULATED }
+        .sortedBy { it.createdTimestamp }
+        .take(amountToExpire)
+        .forEach {
+          it.status = VisitOrderStatus.EXPIRED
+          it.expiryDate = LocalDate.now()
+        }
+    }
+
+    // Expire all PVOs older than 28 days.
+    dpsPrisoner.visitOrders
+      .filter {
+        it.type == VisitOrderType.PVO &&
+          it.status == VisitOrderStatus.AVAILABLE &&
+          it.createdTimestamp.isBefore(LocalDateTime.now().minusDays(28))
+      }
+      .forEach {
+        it.status = VisitOrderStatus.EXPIRED
+        it.expiryDate = LocalDate.now()
+      }
+
+    LOG.info("Completed expiry for prisoner ${dpsPrisoner.prisonerId}")
+  }
+
+  private fun updateLastAllocatedDates(dpsPrisoner: PrisonerDetails, visitOrders: MutableList<VisitOrder>) {
+    // Only update the lastVoAllocatedDate and lastPvoAllocatedDate if VOs and PVOs have been generated.
+    if (visitOrders.any { it.type == VisitOrderType.VO }) {
+      dpsPrisoner.lastVoAllocatedDate = LocalDate.now()
+    }
+    if (visitOrders.any { it.type == VisitOrderType.PVO }) {
+      dpsPrisoner.lastPvoAllocatedDate = LocalDate.now()
+    }
+  }
+
+  private fun createVisitOrder(prisoner: PrisonerDetails, type: VisitOrderType): VisitOrder = VisitOrder(
+    prisonerId = prisoner.prisonerId,
+    type = type,
+    status = VisitOrderStatus.AVAILABLE,
+    createdTimestamp = LocalDateTime.now(),
+    expiryDate = null,
+    prisoner = prisoner,
+  )
+
+  private fun isDueVO(prisoner: PrisonerDetails): Boolean = prisoner.lastVoAllocatedDate <= LocalDate.now().minusDays(14)
+
+  private fun isDuePVO(prisoner: PrisonerDetails): Boolean {
+    val lastPVODate = prisoner.lastPvoAllocatedDate
+
+    // If they haven't been given a PVO before, we wait until their VO due date to allocate it, to align the dates.
+    if (lastPVODate == null) {
+      return isDueVO(prisoner)
+    }
+
+    return lastPVODate <= LocalDate.now().minusDays(28)
+  }
+
+  private fun generateVos(prisoner: PrisonerDetails, prisonIncentivesForPrisonerLevel: PrisonIncentiveAmountsDto): List<VisitOrder> {
+    val visitOrders = mutableListOf<VisitOrder>()
+    if (isDueVO(prisoner)) {
+      val negativeVoCount = prisoner.negativeVisitOrders.count { it.type == VisitOrderType.VO && it.status == NegativeVisitOrderStatus.USED }
+      if (negativeVoCount > 0) {
+        handleNegativeBalanceRepayment(prisonIncentivesForPrisonerLevel.visitOrders, negativeVoCount, prisoner, VisitOrderType.VO, visitOrders)
+      } else {
+        repeat(prisonIncentivesForPrisonerLevel.visitOrders) {
+          visitOrders.add(createVisitOrder(prisoner, VisitOrderType.VO))
+        }
+      }
+    }
+    return visitOrders
+  }
+
+  private fun generatePVos(prisoner: PrisonerDetails, prisonIncentivesForPrisonerLevel: PrisonIncentiveAmountsDto): List<VisitOrder> {
+    val visitOrders = mutableListOf<VisitOrder>()
+
+    if (prisonIncentivesForPrisonerLevel.privilegedVisitOrders != 0 && isDuePVO(prisoner)) {
+      val negativePvoCount = prisoner.negativeVisitOrders.count { it.type == VisitOrderType.PVO && it.status == NegativeVisitOrderStatus.USED }
+      if (negativePvoCount > 0) {
+        handleNegativeBalanceRepayment(prisonIncentivesForPrisonerLevel.privilegedVisitOrders, negativePvoCount, prisoner, VisitOrderType.PVO, visitOrders)
+      } else {
+        repeat(prisonIncentivesForPrisonerLevel.privilegedVisitOrders) {
+          visitOrders.add(createVisitOrder(prisoner, VisitOrderType.PVO))
+        }
+      }
+    }
+    return visitOrders
+  }
+
+  private fun handleNegativeBalanceRepayment(incentiveAmount: Int, negativeBalance: Int, prisoner: PrisonerDetails, type: VisitOrderType, visitOrders: MutableList<VisitOrder>) {
+    if (incentiveAmount < negativeBalance) {
+      // If the incentive amount doesn't fully cover debt, then only repay what is possible.
+      prisoner.negativeVisitOrders
+        .filter { it.type == type && it.status == NegativeVisitOrderStatus.USED }
+        .sortedBy { it.createdTimestamp }
+        .take(incentiveAmount)
+        .forEach {
+          it.status = NegativeVisitOrderStatus.REPAID
+          it.repaidDate = LocalDate.now()
+        }
+    } else {
+      // If the incentive amount pushes the balance positive, repay all debt and generate the required amount of positive VO / PVOs.
+      prisoner.negativeVisitOrders
+        .filter { it.type == type && it.status == NegativeVisitOrderStatus.USED }
+        .forEach {
+          it.status = NegativeVisitOrderStatus.REPAID
+          it.repaidDate = LocalDate.now()
+        }
+
+      val visitOrdersToCreate = incentiveAmount - negativeBalance
+
+      repeat(visitOrdersToCreate) {
+        visitOrders.add(createVisitOrder(prisoner, type))
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
@@ -23,7 +23,7 @@ class VisitAllocationPrisonerRetryQueueListener(private val prisonerRetryService
   @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
   fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.current().asContextElement()).future {
     log.debug("Processing prisoner on the visits allocation prisoner retry queue - {}", visitAllocationPrisonerRetryJob)
-    prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.prisonerId)
+    prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.jobReference, visitAllocationPrisonerRetryJob.prisonerId)
     null
   }
 }

--- a/src/main/resources/db/migration/V1_12__alter_allocation_prison_job_failed_column_name.sql
+++ b/src/main/resources/db/migration/V1_12__alter_allocation_prison_job_failed_column_name.sql
@@ -1,0 +1,3 @@
+-- Rename column failed_prisoners to failed_or_skipped_prisoners. If a prisoner has no changes, failed_or_skipped will contain this prisoner.
+ALTER TABLE visit_order_allocation_prison_job
+    RENAME COLUMN failed_prisoners TO failed_or_skipped_prisoners;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -13,7 +13,11 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
@@ -34,6 +38,9 @@ class ProcessPrisonerServiceTest {
   @Mock
   private lateinit var prisonerRetryService: PrisonerRetryService
 
+  @Mock
+  private lateinit var changeLogService: ChangeLogService
+
   private lateinit var processPrisonerService: ProcessPrisonerService
 
   @BeforeEach
@@ -43,11 +50,10 @@ class ProcessPrisonerServiceTest {
       incentivesClient,
       prisonerDetailsService,
       prisonerRetryService,
+      changeLogService,
       26,
     )
   }
-
-  // --- Continue Allocation Tests --- \\
 
   /**
    * Scenario 1: Continued allocation triggered, existing STD prisoner is given VO / PVO.
@@ -61,11 +67,22 @@ class ProcessPrisonerServiceTest {
     val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
+    val changeLog = ChangeLog(
+      prisonerId = dpsPrisoner.prisonerId,
+      changeType = ChangeLogType.BATCH_PROCESS,
+      changeSource = ChangeLogSource.SYSTEM,
+      userId = "SYSTEM",
+      comment = "batch process run for prisoner ${dpsPrisoner.prisonerId}",
+      prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    )
 
     // WHEN
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
     whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
+    whenever(changeLogService.createLogBatchProcess(dpsPrisoner)).thenReturn(changeLog)
 
     // Begin test
     runBlocking {
@@ -91,11 +108,22 @@ class ProcessPrisonerServiceTest {
     val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(14), null)
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 0, levelCode = "STD"))
+    val changeLog = ChangeLog(
+      prisonerId = dpsPrisoner.prisonerId,
+      changeType = ChangeLogType.BATCH_PROCESS,
+      changeSource = ChangeLogSource.SYSTEM,
+      userId = "SYSTEM",
+      comment = "batch process run for prisoner ${dpsPrisoner.prisonerId}",
+      prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    )
 
     // WHEN
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
     whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
+    whenever(changeLogService.createLogBatchProcess(dpsPrisoner)).thenReturn(changeLog)
 
     // Begin test
     runBlocking {
@@ -120,11 +148,22 @@ class ProcessPrisonerServiceTest {
     val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(14), LocalDate.now().minusDays(14))
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
+    val changeLog = ChangeLog(
+      prisonerId = dpsPrisoner.prisonerId,
+      changeType = ChangeLogType.BATCH_PROCESS,
+      changeSource = ChangeLogSource.SYSTEM,
+      userId = "SYSTEM",
+      comment = "batch process run for prisoner ${dpsPrisoner.prisonerId}",
+      prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    )
 
     // WHEN
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
     whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
+    whenever(changeLogService.createLogBatchProcess(dpsPrisoner)).thenReturn(changeLog)
 
     // Begin test
     runBlocking {
@@ -180,11 +219,22 @@ class ProcessPrisonerServiceTest {
     val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(14), LocalDate.now().minusDays(28))
     val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
     val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
+    val changeLog = ChangeLog(
+      prisonerId = dpsPrisoner.prisonerId,
+      changeType = ChangeLogType.BATCH_PROCESS,
+      changeSource = ChangeLogSource.SYSTEM,
+      userId = "SYSTEM",
+      comment = "batch process run for prisoner ${dpsPrisoner.prisonerId}",
+      prisoner = dpsPrisoner,
+      visitOrderBalance = dpsPrisoner.getVoBalance(),
+      privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    )
 
     // WHEN
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
     whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
     whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
+    whenever(changeLogService.createLogBatchProcess(dpsPrisoner)).thenReturn(changeLog)
 
     // Begin test
     runBlocking {
@@ -193,68 +243,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
-  }
-
-  // --- Accumulation --- \\
-
-  /**
-   * Scenario 1: Existing prisoner with VOs older than 28 days, has VO status updated form 'Available' to 'Accumulated'. But no VOs are expired.
-   */
-  @Test
-  fun `Accumulation - Given an existing prisoner has existing VOs older than 28 days, they are moved to accumulated`() {
-    // GIVEN - A new prisoner with Standard incentive level, in prison MDI
-    val prisonerId = "AA123456"
-    val prisonId = "MDI"
-
-    val prisonerSearchResult = createPrisonerDto(prisonerId, prisonId, "IN")
-
-    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), LocalDate.now().minusDays(14))
-    val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
-    val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
-
-    // WHEN
-    whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
-    whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
-    whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
-
-    // Begin test
-    runBlocking {
-      processPrisonerService.processPrisoner(prisonerId, "allocation-job-ref", prisonIncentiveAmounts)
-    }
-
-    // THEN
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
-  }
-
-  // --- Expiration --- \\
-
-  /**
-   * Scenario 1: Existing prisoner with more than 26 VOs has their oldest VOs over 26 days expired and PVOs older than 28days are expired.
-   */
-  @Test
-  fun `Expiration - Given an existing prisoner has more than 26 VOs, the extra VOs are moved to expired`() {
-    // GIVEN - An existing prisoner with Standard incentive level, in prison MDI
-    val prisonerId = "AA123456"
-    val prisonId = "MDI"
-
-    val prisonerSearchResult = createPrisonerDto(prisonerId, prisonId, "IN")
-
-    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now().minusDays(1), LocalDate.now().minusDays(14))
-    val prisonerIncentive = PrisonerIncentivesDto(iepCode = "STD")
-    val prisonIncentiveAmounts = listOf(PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
-
-    // WHEN
-    whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(dpsPrisoner)
-    whenever(prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId)).thenReturn(prisonerSearchResult)
-    whenever(incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)).thenReturn(prisonerIncentive)
-
-    // Begin test
-    runBlocking {
-      processPrisonerService.processPrisoner(prisonerId, "allocation-job-ref", prisonIncentiveAmounts)
-    }
-
-    // THEN
     verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.Pris
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.NegativeVisitOrderRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderAllocationPrisonJobRepository
@@ -130,6 +131,9 @@ abstract class EventsIntegrationTestBase {
 
   @MockitoSpyBean
   lateinit var changeLogService: ChangeLogService
+
+  @MockitoSpyBean
+  lateinit var changeLogRepository: ChangeLogRepository
 
   @AfterEach
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -38,6 +38,14 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById("TEST", prisoner = createPrisonerDto(prisonerId = prisonerId, prisonId = "HEI", inOutStatus = "IN"))
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", prisonIncentiveAmountsDto = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
 
@@ -46,7 +54,7 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(visitAllocationPrisonerRetryQueueListenerSpy, times(1)).processMessage(visitAllocationPrisonerRetryJob) }
     await untilAsserted { verify(prisonerDetailsRepository, times(2)).save(any()) }
     val visitOrders = visitOrderRepository.findAll()
-    Assertions.assertThat(visitOrders.size).isEqualTo(3)
+    Assertions.assertThat(visitOrders.size).isEqualTo(1) //  STD level = 1 VO & 0 PVO
   }
 
   @Test
@@ -61,6 +69,14 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById("TEST", null, HttpStatus.NOT_FOUND)
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", prisonIncentiveAmountsDto = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
 
@@ -85,6 +101,14 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById("TEST", null, HttpStatus.INTERNAL_SERVER_ERROR)
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", prisonIncentiveAmountsDto = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
 
@@ -109,6 +133,14 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = "HEI", inOutStatus = "IN"))
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", null, HttpStatus.NOT_FOUND)
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", prisonIncentiveAmountsDto = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
 
@@ -133,6 +165,14 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = "HEI", inOutStatus = "IN"))
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", null, HttpStatus.INTERNAL_SERVER_ERROR)
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", prisonIncentiveAmountsDto = PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "STD"))
 
@@ -157,6 +197,13 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = "HEI", inOutStatus = "IN"))
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", null, HttpStatus.NOT_FOUND)
 
@@ -181,6 +228,13 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // When
     prisonVisitsAllocationPrisonerRetryQueueSqsClient.sendMessage(sendMessageRequest)
     prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = "HEI", inOutStatus = "IN"))
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = "HEI",
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
     incentivesMockServer.stubGetPrisonerIncentiveReviewHistory("TEST", prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
     incentivesMockServer.stubGetPrisonIncentiveLevelsByLevelCode(prisonId = "HEI", levelCode = "STD", null, HttpStatus.INTERNAL_SERVER_ERROR)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -101,7 +101,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedPrisoners = 0)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
 
   /**
@@ -169,7 +169,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedPrisoners = 0)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
 
   /**
@@ -234,7 +234,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedPrisoners = 0)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
 
   /**
@@ -310,7 +310,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 2, processedPrisoners = 2, failedPrisoners = 0)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 2, processedPrisoners = 2, failedOrSkippedPrisoners = 0)
   }
 
   /**
@@ -384,7 +384,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
         assertVisitOrdersAssignedBy(visitOrders, prisoner3.prisonerId, VisitOrderType.PVO, VisitOrderStatus.AVAILABLE, 2)
 
         val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-        assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedPrisoners = 0)
+        assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
       }
   }
 
@@ -460,7 +460,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
         assertVisitOrdersAssignedBy(visitOrders, prisoner3.prisonerId, VisitOrderType.PVO, VisitOrderStatus.AVAILABLE, 2)
         assertVisitOrdersAssignedBy(visitOrders, prisoner3.prisonerId, VisitOrderType.PVO, VisitOrderStatus.EXPIRED, 2)
         val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-        assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedPrisoners = 0)
+        assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
 
         assertThat(visitOrders.size).isEqualTo(36)
       }
@@ -538,7 +538,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedPrisoners = 1)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedOrSkippedPrisoners = 1)
   }
 
   /**
@@ -613,7 +613,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedPrisoners = 1)
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedOrSkippedPrisoners = 1)
   }
 
   /**
@@ -638,7 +638,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
       assertThat(visitOrders.size).isEqualTo(0)
       val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get convicted prisoners by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedPrisoners = null)
+      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get convicted prisoners by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedOrSkippedPrisoners = null)
     }
   }
 
@@ -665,7 +665,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
       assertThat(visitOrders.size).isEqualTo(0)
       val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get convicted prisoners by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedPrisoners = null)
+      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get convicted prisoners by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedOrSkippedPrisoners = null)
     }
   }
 
@@ -693,7 +693,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
       assertThat(visitOrders.size).isEqualTo(0)
       val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get incentive levels by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedPrisoners = null)
+      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get incentive levels by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedOrSkippedPrisoners = null)
     }
   }
 
@@ -722,8 +722,55 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
       assertThat(visitOrders.size).isEqualTo(0)
       val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
-      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get incentive levels by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedPrisoners = null)
+      assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], failureMessage = "failed to get incentive levels by prisonId - $PRISON_CODE", convictedPrisoners = null, processedPrisoners = null, failedOrSkippedPrisoners = null)
     }
+  }
+
+  /**
+   * Scenario - No changes: Visit allocation job is run, but no prisoners are due any changes.
+   */
+  @Test
+  fun `when visit allocation job run for a prison then processMessage is called but prisoner isn't due any changes, no change log is generated`() {
+    // Given - message sent to start allocation job for prison
+    val sendMessageRequestBuilder = SendMessageRequest.builder().queueUrl(prisonVisitsAllocationEventJobQueueUrl)
+    val allocationJobReference = "job-ref"
+    val event = VisitAllocationEventJob(allocationJobReference, PRISON_CODE)
+    val message = objectMapper.writeValueAsString(event)
+    val sendMessageRequest = sendMessageRequestBuilder.messageBody(message).build()
+    visitOrderAllocationPrisonJobRepository.save(VisitOrderAllocationPrisonJob(allocationJobReference = allocationJobReference, prisonCode = PRISON_CODE))
+
+    entityHelper.createPrisonerDetails(PrisonerDetails(prisonerId = prisoner1.prisonerId, LocalDate.now().minusDays(1), LocalDate.now().minusDays(1)))
+    entityHelper.createAndSaveVisitOrders(prisoner1.prisonerId, VisitOrderType.VO, VisitOrderStatus.AVAILABLE, LocalDate.now().minusDays(1).atStartOfDay(), 2)
+    entityHelper.createAndSaveNegativeVisitOrders(prisoner1.prisonerId, VisitOrderType.VO, 2)
+
+    // When
+    val convictedPrisoners = listOf(prisoner1)
+    prisonerSearchMockServer.stubGetConvictedPrisoners(PRISON_CODE, convictedPrisoners)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner1.prisonerId, createPrisonerDto(prisonerId = prisoner1.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner1.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
+
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = PRISON_CODE,
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+      ),
+    )
+
+    prisonVisitsAllocationEventJobSqsClient.sendMessage(sendMessageRequest)
+
+    await untilCallTo { prisonVisitsAllocationEventJobSqsClient.countMessagesOnQueue(prisonVisitsAllocationEventJobQueueUrl).get() } matches { it == 0 }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(event) }
+    await untilAsserted { verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any()) }
+
+    val changeLogs = changeLogRepository.findAllByPrisonerId(prisoner1.prisonerId)
+    assertThat(changeLogs).isNullOrEmpty()
+
+    verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
+    verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 1, processedPrisoners = 0, failedOrSkippedPrisoners = 1)
   }
 
   private fun assertVisitOrdersAssignedBy(visitOrders: List<VisitOrder>, prisonerId: String, type: VisitOrderType, status: VisitOrderStatus, total: Int) {
@@ -739,13 +786,13 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     failureMessage: String?,
     convictedPrisoners: Int?,
     processedPrisoners: Int?,
-    failedPrisoners: Int?,
+    failedOrSkippedPrisoners: Int?,
   ) {
     assertThat(visitOrderAllocationPrisonJob.startTimestamp).isNotNull()
     assertThat(visitOrderAllocationPrisonJob.failureMessage).isEqualTo(failureMessage)
     assertThat(visitOrderAllocationPrisonJob.convictedPrisoners).isEqualTo(convictedPrisoners)
     assertThat(visitOrderAllocationPrisonJob.processedPrisoners).isEqualTo(processedPrisoners)
-    assertThat(visitOrderAllocationPrisonJob.failedPrisoners).isEqualTo(failedPrisoners)
+    assertThat(visitOrderAllocationPrisonJob.failedOrSkippedPrisoners).isEqualTo(failedOrSkippedPrisoners)
     assertThat(visitOrderAllocationPrisonJob.endTimestamp).isNotNull()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -27,7 +27,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderAl
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs.VisitAllocationEventJob
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
 class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
@@ -749,6 +748,4 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     assertThat(visitOrderAllocationPrisonJob.failedPrisoners).isEqualTo(failedPrisoners)
     assertThat(visitOrderAllocationPrisonJob.endTimestamp).isNotNull()
   }
-
-  private fun createVisitOrder(type: VisitOrderType, status: VisitOrderStatus, createdDateTime: LocalDateTime, prisoner: PrisonerDetails): VisitOrder = VisitOrder(prisonerId = prisoner.prisonerId, type = type, status = status, createdTimestamp = createdDateTime, prisoner = prisoner)
 }


### PR DESCRIPTION
Ready for when we need to publish event per prisoner after processing, we need to ensure the prisoners transaction has fully committed before raising the event.