### PR TITLE
Domain event raising on allocation API

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,13 @@ kubectl create job --from=cronjob/hmpps-visit-allocation-api-allocate-visit-orde
 ```
 
 ### Syncing with NOMIS
-(TODO, change to 2-way when implemented)
+This service has a 2-way sync with NOMIS. 
 
-This service has a 1-way sync with NOMIS. When visit order data on NOMIS changes for a prisoner, a request will 
-be made to this service, to sync the change so that DPS can be aligned with NOMIS. See the NomisController.kt for more 
-information.
+##### NOMIS -> DPS
+When visit order data on NOMIS changes for a prisoner, a request will be made to this service, to sync the change so that 
+DPS can be aligned with NOMIS. See the NomisController.kt for more information.
+
+##### DPS -> NOMIS
+When prisoner balance changes and the prison is owned by this service (enabled in prison DB table), an event will be raised for 
+NOMIS to listen and consume. Event name: "prison-visit-allocation.adjustment.created". The event will contain a prisoner ID and 
+adjustment ID which NOMIS can then use to call via the NomisController "getPrisonerAdjustment" endpoint to re-sync with DPS.

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -14,6 +14,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api-dev.hmpps.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
+    FEATURE_EVENTS_SNS_ENABLED: true
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api-preprod.hmpps.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api-preprod.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
+    FEATURE_EVENTS_SNS_ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -11,6 +11,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api.hmpps.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
+    FEATURE_EVENTS_SNS_ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -14,6 +14,7 @@ generic-service:
     INCENTIVES_API_URL: "https://incentives-api-dev.hmpps.service.justice.gov.uk"
     PRISON_API_URL: "https://prison-api-dev.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
+    FEATURE_EVENTS_SNS_ENABLED: false # A lot of DPS services don't have staging. Disabling.
 
   scheduledDowntime:
     enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/exception/PublishEventException.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/exception/PublishEventException.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.exception
+
+import java.util.function.Supplier
+
+class PublishEventException(message: String? = null, cause: Throwable? = null) :
+  RuntimeException(message, cause),
+  Supplier<PublishEventException> {
+  override fun get(): PublishEventException = PublishEventException(message, cause)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -16,6 +16,7 @@ class AllocationService(
   private val incentivesClient: IncentivesClient,
   private val prisonService: PrisonService,
   private val processPrisonerService: ProcessPrisonerService,
+  private val snsService: SnsService,
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -39,7 +40,7 @@ class AllocationService(
 
       if (changeLog != null) {
         totalConvictedPrisonersProcessed++
-        // TODO: Publish event using changeLog captured above
+        snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
       } else {
         totalConvictedPrisonersFailedOrSkipped++
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -18,7 +18,6 @@ class DomainEventListenerService(private val handlerRegistry: DomainEventHandler
       handler.handle(domainEvent)
     } else {
       LOG.error("No handler found for event type: {}", domainEvent.eventType)
-      throw IllegalArgumentException("No handler found for event type ${domainEvent.eventType}")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
@@ -17,6 +17,7 @@ class PrisonerRetryService(
   private val prisonerSearchClient: PrisonerSearchClient,
   @Lazy
   private val processPrisonerService: ProcessPrisonerService,
+  private val snsService: SnsService,
 ) {
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -37,7 +38,9 @@ class PrisonerRetryService(
     val prisoner = prisonerSearchClient.getPrisonerById(prisonerId)
     val allIncentiveLevels = getIncentiveLevelsForPrison(prisonId = prisoner.prisonId)
     val changeLog = processPrisonerService.processPrisoner(prisonerId, jobReference, allIncentiveLevels, fromRetryQueue = true)
-    // TODO: Publish event using changeLog captured above
+    if (changeLog != null) {
+      snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
+    }
   }
 
   private fun getIncentiveLevelsForPrison(prisonId: String): List<PrisonIncentiveAmountsDto> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/SnsService.kt
@@ -1,0 +1,101 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.microsoft.applicationinsights.TelemetryClient
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.sns.model.MessageAttributeValue
+import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.PublishEventException
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@Service
+class SnsService(
+  private val hmppsQueueService: HmppsQueueService,
+  private val telemetryClient: TelemetryClient,
+  private val objectMapper: ObjectMapper,
+  @Value("\${feature.events.sns.enabled:true}")
+  private val snsEventsEnabled: Boolean,
+) {
+
+  companion object {
+    const val TOPIC_ID = "domainevents"
+    const val EVENT_ZONE_ID = "Europe/London"
+    const val EVENT_PRISON_VISIT_VERSION = 1
+    const val EVENT_PRISON_ALLOCATION_ADJUSTMENT_CREATED = "prison-visit-allocation.adjustment.created"
+    const val EVENT_PRISON_ALLOCATION_ADJUSTMENT_CREATED_DESC = "Prisoner balance adjusted via nightly allocation-api batch job"
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  private val domainEventsTopic by lazy { hmppsQueueService.findByTopicId(TOPIC_ID) ?: throw RuntimeException("Topic with name $TOPIC_ID doesn't exist") }
+  private val domainEventsTopicClient by lazy { domainEventsTopic.snsClient }
+
+  fun LocalDateTime.toOffsetDateFormat(): String = atZone(ZoneId.of(EVENT_ZONE_ID)).toOffsetDateTime().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+
+  fun sendPrisonAllocationAdjustmentCreatedEvent(changeLog: ChangeLog) {
+    publishToDomainEventsTopic(
+      HMPPSDomainEvent(
+        eventType = EVENT_PRISON_ALLOCATION_ADJUSTMENT_CREATED,
+        version = EVENT_PRISON_VISIT_VERSION,
+        description = EVENT_PRISON_ALLOCATION_ADJUSTMENT_CREATED_DESC,
+        occurredAt = changeLog.changeTimestamp.toOffsetDateFormat(),
+        prisonerId = changeLog.prisonerId,
+        additionalInformation = AdditionalInformation(
+          prisonerId = changeLog.prisonerId,
+          adjustmentId = changeLog.id,
+        ),
+      ),
+    )
+  }
+
+  private fun publishToDomainEventsTopic(payloadEvent: HMPPSDomainEvent) {
+    if (!snsEventsEnabled) {
+      LOG.warn("Publish to domain events topic Disabled")
+      return
+    }
+    LOG.debug("Entered : publishToDomainEventsTopic {}", payloadEvent)
+
+    try {
+      val messageAttributes = mutableMapOf(
+        "eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payloadEvent.eventType).build(),
+      )
+
+      val publishRequest = PublishRequest.builder().topicArn(domainEventsTopic.arn)
+        .message(objectMapper.writeValueAsString(payloadEvent))
+        .messageAttributes(messageAttributes)
+        .build()
+
+      val result = domainEventsTopicClient.publish(publishRequest).join()
+
+      telemetryClient.trackEvent(
+        "${payloadEvent.eventType}-domain-event",
+        mapOf("messageId" to result.messageId(), "adjustmentId" to payloadEvent.additionalInformation.adjustmentId.toString()),
+        null,
+      )
+    } catch (e: Throwable) {
+      val message = "Failed (publishToDomainEventsTopic) to publish Event $payloadEvent.eventType to $TOPIC_ID"
+      LOG.error(message, e)
+      throw PublishEventException(message, e)
+    }
+  }
+}
+
+internal data class AdditionalInformation(
+  val prisonerId: String,
+  val adjustmentId: Long,
+)
+
+internal data class HMPPSDomainEvent(
+  val eventType: String,
+  val version: Int,
+  val description: String,
+  val occurredAt: String,
+  val prisonerId: String,
+  val additionalInformation: AdditionalInformation,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationEventJobSqsService.kt
@@ -5,8 +5,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.PublishEventException
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
-import java.util.function.Supplier
 
 @Service
 class VisitAllocationEventJobSqsService(
@@ -47,9 +47,3 @@ data class VisitAllocationEventJob(
   val jobReference: String,
   val prisonCode: String,
 )
-
-class PublishEventException(message: String? = null, cause: Throwable? = null) :
-  RuntimeException(message, cause),
-  Supplier<PublishEventException> {
-  override fun get(): PublishEventException = PublishEventException(message, cause)
-}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/sqs/VisitAllocationPrisonerRetrySqsService.kt
@@ -5,6 +5,7 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.PublishEventException
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,3 +90,8 @@ hmpps:
 
 domain-event-processing:
     enabled: ${SQS_DOMAIN_EVENT_PROCESSING_ENABLED}
+
+feature:
+  events:
+    sns:
+      enabled: true

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.integration.events
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.microsoft.applicationinsights.TelemetryClient
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.extension.ExtendWith
@@ -38,6 +39,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.repository.VisitOrderRepo
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.DomainEventListenerService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.SnsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener.Companion.PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.VisitAllocationByPrisonJobListener
@@ -134,6 +136,12 @@ abstract class EventsIntegrationTestBase {
 
   @MockitoSpyBean
   lateinit var changeLogRepository: ChangeLogRepository
+
+  @MockitoSpyBean
+  lateinit var snsService: SnsService
+
+  @MockitoSpyBean
+  lateinit var telemetryClient: TelemetryClient
 
   @AfterEach
   @BeforeEach

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -53,6 +53,8 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     await untilCallTo { prisonVisitsAllocationPrisonerRetryQueueSqsClient.countMessagesOnQueue(prisonVisitsAllocationPrisonerRetryQueueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(visitAllocationPrisonerRetryQueueListenerSpy, times(1)).processMessage(visitAllocationPrisonerRetryJob) }
     await untilAsserted { verify(prisonerDetailsRepository, times(2)).save(any()) }
+    await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
     val visitOrders = visitOrderRepository.findAll()
     Assertions.assertThat(visitOrders.size).isEqualTo(1) //  STD level = 1 VO & 0 PVO
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/SnsDisabledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/SnsDisabledTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration.events
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.springframework.test.context.TestPropertySource
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.PRISON_CODE
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner1
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner2
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner3
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.IncentivesMockExtension.Companion.incentivesMockServer
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.PrisonerSearchMockExtension.Companion.prisonerSearchMockServer
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs.VisitAllocationEventJob
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+@TestPropertySource(properties = ["feature.events.sns.enabled=false"])
+class SnsDisabledTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `prison visit allocation batch jobs runs - no event sent`() {
+    // Given
+    val sendMessageRequestBuilder = SendMessageRequest.builder().queueUrl(prisonVisitsAllocationEventJobQueueUrl)
+    val allocationJobReference = "job-ref"
+    val event = VisitAllocationEventJob(allocationJobReference, PRISON_CODE)
+    val message = objectMapper.writeValueAsString(event)
+    val sendMessageRequest = sendMessageRequestBuilder.messageBody(message).build()
+
+    // When
+    val convictedPrisoners = listOf(prisoner1, prisoner2, prisoner3)
+    prisonerSearchMockServer.stubGetConvictedPrisoners(PRISON_CODE, convictedPrisoners)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner1.prisonerId, createPrisonerDto(prisonerId = prisoner1.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner2.prisonerId, createPrisonerDto(prisonerId = prisoner2.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner3.prisonerId, createPrisonerDto(prisonerId = prisoner3.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner1.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner2.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("ENH"))
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner3.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("ENH2"))
+
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = PRISON_CODE,
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
+
+    prisonVisitsAllocationEventJobSqsClient.sendMessage(sendMessageRequest)
+
+    // Then
+    await untilCallTo { prisonVisitsAllocationEventJobSqsClient.countMessagesOnQueue(prisonVisitsAllocationEventJobQueueUrl).get() } matches { it == 0 }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(event) }
+    await untilAsserted { verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any()) }
+
+    // And
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+    verifyNoInteractions(telemetryClient)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/SnsEnabledEventsSentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/SnsEnabledEventsSentTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration.events
+
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.matches
+import org.awaitility.kotlin.untilAsserted
+import org.awaitility.kotlin.untilCallTo
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.springframework.test.context.TestPropertySource
+import software.amazon.awssdk.services.sqs.model.SendMessageRequest
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.PRISON_CODE
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner1
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner2
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.events.VisitAllocationByPrisonJobSqsTest.Companion.prisoner3
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.IncentivesMockExtension.Companion.incentivesMockServer
+import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.PrisonerSearchMockExtension.Companion.prisonerSearchMockServer
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs.VisitAllocationEventJob
+import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
+
+@TestPropertySource(properties = ["feature.events.sns.enabled=true"])
+class SnsEnabledEventsSentTest : EventsIntegrationTestBase() {
+
+  @Test
+  fun `prison visit allocation batch jobs runs - event sent`() {
+    // Given
+    val sendMessageRequestBuilder = SendMessageRequest.builder().queueUrl(prisonVisitsAllocationEventJobQueueUrl)
+    val allocationJobReference = "job-ref"
+    val event = VisitAllocationEventJob(allocationJobReference, PRISON_CODE)
+    val message = objectMapper.writeValueAsString(event)
+    val sendMessageRequest = sendMessageRequestBuilder.messageBody(message).build()
+
+    // When
+    val convictedPrisoners = listOf(prisoner1, prisoner2, prisoner3)
+    prisonerSearchMockServer.stubGetConvictedPrisoners(PRISON_CODE, convictedPrisoners)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner1.prisonerId, createPrisonerDto(prisonerId = prisoner1.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner2.prisonerId, createPrisonerDto(prisonerId = prisoner2.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner3.prisonerId, createPrisonerDto(prisonerId = prisoner3.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner1.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner2.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("ENH"))
+    incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner3.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("ENH2"))
+
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = PRISON_CODE,
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+        PrisonIncentiveAmountsDto(visitOrders = 2, privilegedVisitOrders = 1, levelCode = "ENH"),
+        PrisonIncentiveAmountsDto(visitOrders = 3, privilegedVisitOrders = 2, levelCode = "ENH2"),
+      ),
+    )
+
+    prisonVisitsAllocationEventJobSqsClient.sendMessage(sendMessageRequest)
+
+    // Then
+    await untilCallTo { prisonVisitsAllocationEventJobSqsClient.countMessagesOnQueue(prisonVisitsAllocationEventJobQueueUrl).get() } matches { it == 0 }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(event) }
+    await untilAsserted { verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any()) }
+
+    // And
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+    verify(telemetryClient, times(3)).trackEvent(any(), any(), eq(null))
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.springframework.http.HttpStatus
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
@@ -100,6 +101,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
@@ -168,6 +170,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
@@ -233,6 +237,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
   }
@@ -309,6 +315,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(2)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 2, processedPrisoners = 2, failedOrSkippedPrisoners = 0)
   }
@@ -385,6 +393,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
         val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
         assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
+
+        verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
       }
   }
 
@@ -463,6 +473,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
         assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
 
         assertThat(visitOrders.size).isEqualTo(36)
+
+        verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
       }
   }
 
@@ -537,6 +549,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedOrSkippedPrisoners = 1)
   }
@@ -612,6 +626,8 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(3)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 4, processedPrisoners = 3, failedOrSkippedPrisoners = 1)
   }
@@ -769,6 +785,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
 
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
     verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verifyNoInteractions(snsService)
     val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 1, processedPrisoners = 0, failedOrSkippedPrisoners = 1)
   }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -54,3 +54,8 @@ hmpps:
 
 domain-event-processing:
   enabled: true
+
+feature:
+  events:
+    sns:
+      enabled: true


### PR DESCRIPTION
## What does this PR do?
when a prisoners balance changes due to our nightly allocation (or via retry queue processing). We now raise an event which allows NOMIS to consume, call our service and get the new balance information for that prisoner.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5235