### PR TITLE
Change how we return the changeLog entry on prisoner process service

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -34,7 +34,7 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {
     LOG.info("PrisonerDetailsService - updatePrisonerDetails called with new prisoner details - $prisoner")
-    return prisonerDetailsRepository.save(prisoner)
+    return prisonerDetailsRepository.saveAndFlush(prisoner)
   }
 
   fun removePrisonerDetails(prisonerId: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
@@ -53,7 +54,7 @@ class ProcessPrisonerService(
       val savedPrisoner = prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
 
       // Return the inserted change log, which can be used by caller to raise event for prisoner processing.
-      return savedPrisoner.changeLogs.firstOrNull()
+      return savedPrisoner.changeLogs.firstOrNull { it.changeType == ChangeLogType.BATCH_PROCESS && it.changeTimestamp.toLocalDate() == LocalDate.now() }
     } catch (e: Exception) {
       // When a prisoner is processed from the retry queue, we don't want to add them back if an exception happens.
       // Instead, it should go onto the DLQ.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -46,18 +46,14 @@ class ProcessPrisonerService(
       processPrisonerAccumulation(dpsPrisonerDetails)
       processPrisonerExpiration(dpsPrisonerDetails)
 
-      val newChangeLog: ChangeLog?
       if (hasChangeOccurred(dpsPrisonerDetailsBefore, dpsPrisonerDetails)) {
-        newChangeLog = changeLogService.createLogBatchProcess(dpsPrisonerDetails)
-        dpsPrisonerDetails.changeLogs.add(newChangeLog)
-      } else {
-        newChangeLog = null
+        dpsPrisonerDetails.changeLogs.add(changeLogService.createLogBatchProcess(dpsPrisonerDetails))
       }
 
-      prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
+      val savedPrisoner = prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
 
       // Return the inserted change log, which can be used by caller to raise event for prisoner processing.
-      return newChangeLog
+      return savedPrisoner.changeLogs.firstOrNull()
     } catch (e: Exception) {
       // When a prisoner is processed from the retry queue, we don't want to add them back if an exception happens.
       // Instead, it should go onto the DLQ.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
@@ -35,7 +35,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -64,7 +64,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(visitOrderRepository, times(0)).saveAll<VisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(7)
@@ -92,7 +92,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
 
-    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(5)
@@ -126,7 +126,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -159,7 +159,8 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(3)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -182,7 +182,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
     await untilCallTo { domainEventsSqsDlqClient!!.countMessagesOnQueue(domainEventsDlqUrl!!).get() } matches { it == 0 }
-    await untilAsserted { verify(prisonerDetailsRepository, times(2)).save(any()) }
+    await untilAsserted { verify(prisonerDetailsRepository, times(4)).saveAndFlush(any()) }
 
     val prisoner = prisonerDetailsRepository.findById(movedFromPrisonerId).get()
     assertThat(prisoner.visitOrders.count()).isEqualTo(3)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -52,7 +52,7 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { prisonVisitsAllocationPrisonerRetryQueueSqsClient.countMessagesOnQueue(prisonVisitsAllocationPrisonerRetryQueueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(visitAllocationPrisonerRetryQueueListenerSpy, times(1)).processMessage(visitAllocationPrisonerRetryJob) }
-    await untilAsserted { verify(prisonerDetailsRepository, times(2)).save(any()) }
+    await untilAsserted { verify(prisonerDetailsRepository, times(1)).saveAndFlush(any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
     val visitOrders = visitOrderRepository.findAll()


### PR DESCRIPTION
The change_log was not persisting, changed how we get it via capturing the saved prisoner returned and getting the entry from the changeLog list.