### PR TITLE
VB-5475 - Visit cancelled event

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -109,8 +109,8 @@ class ProcessPrisonerService(
       if (negativeVoUsedForVisit != null) {
         dpsPrisonerDetails.negativeVisitOrders.remove(negativeVoUsedForVisit)
       } else {
-        LOG.error("No visit with reference ${visit.reference} associated with prisoner ${visit.prisonerId} found on either visit_order or negative_visit_order balances")
-        throw IllegalStateException("No visit with reference ${visit.reference} associated with prisoner ${visit.prisonerId} found on either visit_order or negative_visit_order balances")
+        LOG.warn("No visit with reference ${visit.reference} associated with prisoner ${visit.prisonerId} found on visit allocation api. Creating VO.")
+        dpsPrisonerDetails.visitOrders.add(createVisitOrder(dpsPrisonerDetails, VisitOrderType.VO))
       }
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
@@ -9,5 +9,5 @@ data class PrisonerConvictionStatusChangedInfo(
   val prisonerId: String,
 
   @NotBlank
-  val convictedStatus: String,
+  val convictedStatus: String? = null,
 )


### PR DESCRIPTION
## What does this PR do?
Fix code after discussions. If during cancel event no VO is found associated with the visit, then simply create a new VO for them.

## JIRA Link
https://dsdmoj.atlassian.net/browse/VB-5475