### PR TITLE
Add row locking for prisoner_details

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -1,8 +1,17 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 
+import jakarta.persistence.LockModeType
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import java.util.*
 
 @Repository
-interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String>
+interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String> {
+
+  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Query("SELECT pd FROM PrisonerDetails pd WHERE pd.prisonerId = :id")
+  fun findByIdForUpdate(id: String): Optional<PrisonerDetails>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -16,5 +16,5 @@ interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String> {
   @Lock(LockModeType.PESSIMISTIC_WRITE)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")])
   @Query("SELECT pd FROM PrisonerDetails pd WHERE pd.prisonerId = :id")
-  fun findByIdForUpdate(id: String): Optional<PrisonerDetails>
+  fun findByIdWithLock(id: String): Optional<PrisonerDetails>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 
 import jakarta.persistence.LockModeType
+import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import java.util.*
@@ -12,6 +14,7 @@ import java.util.*
 interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String> {
 
   @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")])
   @Query("SELECT pd FROM PrisonerDetails pd WHERE pd.prisonerId = :id")
   fun findByIdForUpdate(id: String): Optional<PrisonerDetails>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/BalanceService.kt
@@ -12,7 +12,7 @@ class BalanceService(private val prisonerDetailsService: PrisonerDetailsService)
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @Transactional(readOnly = true)
+  @Transactional
   fun getPrisonerBalance(prisonerId: String): PrisonerBalanceDto? {
     LOG.info("Entered BalanceService - getPrisonerBalance for prisoner $prisonerId")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -26,12 +26,12 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
       ),
     )
 
-    return prisonerDetailsRepository.findByIdForUpdate(prisonerId).get()
+    return prisonerDetailsRepository.findByIdWithLock(prisonerId).get()
   }
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {
     LOG.info("PrisonerDetailsService - getPrisonerDetails called with prisonerId - $prisonerId")
-    return prisonerDetailsRepository.findByIdForUpdate(prisonerId).getOrNull()
+    return prisonerDetailsRepository.findByIdWithLock(prisonerId).getOrNull()
   }
 
   fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -29,7 +29,7 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {
     LOG.info("PrisonerDetailsService - getPrisonerDetails called with prisonerId - $prisonerId")
-    return prisonerDetailsRepository.findById(prisonerId).getOrNull()
+    return prisonerDetailsRepository.findByIdForUpdate(prisonerId).getOrNull()
   }
 
   fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -18,13 +18,15 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId and newLastAllocatedDate - $newLastPvoAllocatedDate")
-    return prisonerDetailsRepository.saveAndFlush(
+    prisonerDetailsRepository.saveAndFlush(
       PrisonerDetails(
         prisonerId = prisonerId,
         lastVoAllocatedDate = newLastAllocatedDate,
         lastPvoAllocatedDate = newLastPvoAllocatedDate,
       ),
     )
+
+    return prisonerDetailsRepository.findByIdForUpdate(prisonerId).get()
   }
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {


### PR DESCRIPTION
## What does this PR do?
Sometimes requests come in within a few milliseconds of each other. This PR aims to add a simple lock on the row, forcing other requests to wait for the first transaction to close before allowing them to grab the latest prisoner_details.