### PR TITLE
Bug fix - Remove manual management of prisoner details entity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -47,7 +47,6 @@ class NomisMigrationService(
 
     dpsPrisoner.changeLogs.add(changeLogService.createLogMigrationChange(migrationDto, dpsPrisoner))
 
-    prisonerDetailsService.updatePrisonerDetails(dpsPrisoner)
     LOG.info("Finished NomisMigrationService - migratePrisoner ${migrationDto.prisonerId} successfully")
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -82,8 +82,6 @@ class NomisSyncService(
     }
 
     dpsPrisoner.changeLogs.add(changeLogService.createLogSyncAdjustmentChange(syncDto, dpsPrisoner))
-
-    prisonerDetailsService.updatePrisonerDetails(prisoner = dpsPrisoner)
   }
 
   fun syncPrisonerBalanceFromEventChange(prisonerId: String, domainEventType: DomainEventType) {
@@ -100,8 +98,6 @@ class NomisSyncService(
         LOG.warn("Prisoner $prisonerId found in DPS allocation service. Resetting balance")
 
         resetDpsPrisonerBalance(dpsPrisoner, domainEventType)
-
-        prisonerDetailsService.updatePrisonerDetails(prisoner = dpsPrisoner)
 
         return
       }
@@ -138,8 +134,6 @@ class NomisSyncService(
       LOG.info("Balance has changed as a result of sync for prisoner $prisonerId, for domain event ${domainEventType.value}")
       dpsPrisoner.changeLogs.add(changeLogService.createLogSyncEventChange(dpsPrisoner, domainEventType))
     }
-
-    prisonerDetailsService.updatePrisonerDetails(prisoner = dpsPrisoner)
   }
 
   fun syncPrisonerRemoved(prisonerId: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/NomisSyncServiceTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
@@ -10,7 +9,6 @@ import org.mockito.Mockito.spy
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -73,17 +71,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.visitOrders.size).isEqualTo(6)
   }
 
   /**
@@ -119,7 +111,6 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -140,17 +131,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.negativeVisitOrders.size).isEqualTo(2)
   }
 
   // == Negative Balance paths == \\
@@ -190,17 +175,11 @@ class NomisSyncServiceTest {
       .thenReturn(spyDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.firstValue
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.negativeVisitOrders.size).isEqualTo(3)
   }
 
   /**
@@ -236,7 +215,6 @@ class NomisSyncServiceTest {
 
     // THEN
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(any())
 
     verifyNoInteractions(telemetryClientService)
   }
@@ -257,17 +235,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.visitOrders.size).isEqualTo(2)
   }
 
   // == Zero Balance paths == \
@@ -286,17 +258,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.visitOrders.size).isEqualTo(3)
   }
 
   /**
@@ -313,17 +279,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncAdjustmentChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.negativeVisitOrders.size).isEqualTo(3)
   }
 
   // Nomis Sync via events tests \\
@@ -346,17 +306,11 @@ class NomisSyncServiceTest {
     whenever(prisonerDetailsService.getPrisonerDetails(prisonerId)).thenReturn(existingPrisonerDetails)
 
     // WHEN
-    val prisonerDetailsCaptor = argumentCaptor<PrisonerDetails>()
     nomisSyncService.syncPrisonerBalanceFromEventChange(prisonerId, DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE)
 
     // THEN
-    verify(prisonerDetailsService, times(1)).updatePrisonerDetails(prisonerDetailsCaptor.capture())
     verify(changeLogService, times(1)).createLogSyncEventChange(any(), any())
     verifyNoInteractions(telemetryClientService)
-
-    val savedPrisonerDetails = prisonerDetailsCaptor.allValues[0]
-    assertThat(savedPrisonerDetails.prisonerId).isEqualTo(prisonerId)
-    assertThat(savedPrisonerDetails.visitOrders.size).isEqualTo(5)
   }
 
   private fun createSyncRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
@@ -35,7 +35,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -64,7 +64,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(visitOrderRepository, times(0)).saveAll<VisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(7)
@@ -92,7 +92,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
 
-    verify(prisonerDetailsRepository, times(2)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(5)
@@ -126,7 +126,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(2)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -160,7 +160,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
     verify(prisonerDetailsRepository, times(1)).save<PrisonerDetails>(any())
-    verify(prisonerDetailsRepository, times(2)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -190,7 +190,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
     await untilCallTo { domainEventsSqsDlqClient!!.countMessagesOnQueue(domainEventsDlqUrl!!).get() } matches { it == 0 }
-    await untilAsserted { verify(prisonerDetailsRepository, times(4)).saveAndFlush(any()) }
+    await untilAsserted { verify(prisonerDetailsRepository, times(2)).saveAndFlush(any()) }
 
     val prisoner = prisonerDetailsRepository.findById(movedFromPrisonerId).get()
     assertThat(prisoner.visitOrders.count()).isEqualTo(3)


### PR DESCRIPTION
## What does this PR do?
Remove the manual call to save the updated prisoner details, as this was overwriting hibernates management of the entity and causing data to be wiped if two requests came in at the same time.

## Next?
This is part 1 of the fix, to sort out the nomis sync endpoints first. I'll next sort the dps allocation side (which isn't in use yet).