### PR TITLE
Fix Bug - Overwriting data part 2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
@@ -13,6 +13,7 @@ import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import java.time.LocalDateTime
+import java.util.UUID
 
 @Entity
 @Table(name = "change_log")
@@ -50,4 +51,7 @@ data class ChangeLog(
   @ManyToOne
   @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
   val prisoner: PrisonerDetails,
+
+  @Column(nullable = false)
+  val reference: UUID,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
@@ -4,10 +4,13 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
+import java.util.*
 
 @Repository
 interface ChangeLogRepository : JpaRepository<ChangeLog, Long> {
   fun findAllByPrisonerId(prisonerId: String): List<ChangeLog>?
 
   fun findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId: String, changeType: ChangeLogType): ChangeLog?
+
+  fun findFirstByPrisonerIdAndReference(prisonerId: String, reference: UUID): ChangeLog?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -130,6 +130,8 @@ class ChangeLogService(val changeLogRepository: ChangeLogRepository) {
 
   fun findChangeLogForPrisonerByType(prisonerId: String, changeLogType: ChangeLogType): ChangeLog? = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, changeLogType)
 
+  fun findChangeLogForPrisonerByReference(prisonerId: String, reference: UUID): ChangeLog? = changeLogRepository.findFirstByPrisonerIdAndReference(prisonerId, reference)
+
   private fun createChangeLog(
     dpsPrisoner: PrisonerDetails,
     changeLogType: ChangeLogType,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundExcepti
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.ChangeLogRepository
+import java.util.*
 
 @Transactional
 @Service
@@ -144,5 +145,6 @@ class ChangeLogService(val changeLogRepository: ChangeLogRepository) {
     prisoner = dpsPrisoner,
     visitOrderBalance = dpsPrisoner.getVoBalance(),
     privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+    reference = UUID.randomUUID(),
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -34,11 +34,6 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
     return prisonerDetailsRepository.findByIdWithLock(prisonerId).getOrNull()
   }
 
-  fun updatePrisonerDetails(prisoner: PrisonerDetails): PrisonerDetails {
-    LOG.info("PrisonerDetailsService - updatePrisonerDetails called with new prisoner details - $prisoner")
-    return prisonerDetailsRepository.saveAndFlush(prisoner)
-  }
-
   fun removePrisonerDetails(prisonerId: String) {
     LOG.info("PrisonerDetailsService - removePrisonerDetails called with prisonerId - $prisonerId")
     val prisoner = prisonerDetailsRepository.findById(prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -172,7 +172,6 @@ class ProcessPrisonerService(
       )
       newPrisonerDetails.changeLogs.add(changeLog)
 
-      prisonerDetailsService.updatePrisonerDetails(newPrisonerDetails)
       telemetryClientService.trackEvent(
         TelemetryEventType.VO_ADDED_POST_MERGE,
         mapOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -189,7 +189,7 @@ class ProcessPrisonerService(
   }
 
   @Transactional
-  fun processPrisonerReceivedResetBalance(prisonerId: String, reason: PrisonerReceivedReasonType): ChangeLog? {
+  fun processPrisonerReceivedResetBalance(prisonerId: String, reason: PrisonerReceivedReasonType): UUID {
     val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
 
@@ -207,9 +207,8 @@ class ProcessPrisonerService(
         it.repaidDate = LocalDate.now()
       }
 
-    dpsPrisonerDetails.changeLogs.add(changeLogService.createLogPrisonerBalanceReset(dpsPrisonerDetails, reason))
-
-    prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
+    val changeLog = changeLogService.createLogPrisonerBalanceReset(dpsPrisonerDetails, reason)
+    dpsPrisonerDetails.changeLogs.add(changeLog)
 
     telemetryClientService.trackEvent(
       TelemetryEventType.VO_PRISONER_BALANCE_RESET,
@@ -219,7 +218,7 @@ class ProcessPrisonerService(
       ),
     )
 
-    return changeLogService.findChangeLogForPrisonerByType(prisonerId, ChangeLogType.PRISONER_BALANCE_RESET)
+    return changeLog.reference
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -130,7 +130,7 @@ class ProcessPrisonerService(
   }
 
   @Transactional
-  fun processPrisonerMerge(newPrisonerId: String, removedPrisonerId: String): ChangeLog? {
+  fun processPrisonerMerge(newPrisonerId: String, removedPrisonerId: String): UUID? {
     var visitOrdersToBeCreated = 0
     var privilegedVisitOrdersToBeCreated = 0
 
@@ -182,7 +182,7 @@ class ProcessPrisonerService(
           "pvoAddedPostMerge" to privilegedVisitOrdersToBeCreated.toString(),
         ),
       )
-      changeLogService.findChangeLogForPrisonerByType(newPrisonerId, ChangeLogType.ALLOCATION_ADDED_AFTER_PRISONER_MERGE)
+      changeLog.reference
     } else {
       LOG.info("No VOs / PVOs were added post merge of prisonerId - $newPrisonerId and removedPrisonerId - $removedPrisonerId")
       null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -89,7 +89,7 @@ class ProcessPrisonerService(
   }
 
   @Transactional
-  fun processPrisonerVisitOrderRefund(visit: VisitDto): ChangeLog? {
+  fun processPrisonerVisitOrderRefund(visit: VisitDto): UUID {
     val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
 
@@ -115,9 +115,8 @@ class ProcessPrisonerService(
       }
     }
 
-    dpsPrisonerDetails.changeLogs.add(changeLogService.createLogAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference))
-
-    prisonerDetailsService.updatePrisonerDetails(dpsPrisonerDetails)
+    val changeLog = changeLogService.createLogAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference)
+    dpsPrisonerDetails.changeLogs.add(changeLog)
 
     telemetryClientService.trackEvent(
       TelemetryEventType.VO_REFUNDED_AFTER_VISIT_CANCELLATION,
@@ -127,7 +126,7 @@ class ProcessPrisonerService(
       ),
     )
 
-    return changeLogService.findChangeLogForPrisonerByType(visit.prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)
+    return changeLog.reference
   }
 
   @Transactional

--- a/src/main/resources/db/migration/V1_17__alter_change_log_table_add_reference_column.sql
+++ b/src/main/resources/db/migration/V1_17__alter_change_log_table_add_reference_column.sql
@@ -1,7 +1,3 @@
-BEGIN;
-
 ALTER TABLE change_log ADD COLUMN reference UUID;
 UPDATE change_log SET reference = gen_random_uuid() WHERE reference IS NULL;
 ALTER TABLE change_log ALTER COLUMN reference SET NOT NULL;
-
-COMMIT;

--- a/src/main/resources/db/migration/V1_17__alter_change_log_table_add_reference_column.sql
+++ b/src/main/resources/db/migration/V1_17__alter_change_log_table_add_reference_column.sql
@@ -1,0 +1,7 @@
+BEGIN;
+
+ALTER TABLE change_log ADD COLUMN reference UUID;
+UPDATE change_log SET reference = gen_random_uuid() WHERE reference IS NULL;
+ALTER TABLE change_log ALTER COLUMN reference SET NOT NULL;
+
+COMMIT;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -376,10 +376,8 @@ class ProcessPrisonerServiceTest {
     processPrisonerService.processPrisonerReceivedResetBalance(prisonerId, PrisonerReceivedReasonType.NEW_ADMISSION)
 
     // THEN
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
     verify(changeLogService).createLogPrisonerBalanceReset(dpsPrisoner, PrisonerReceivedReasonType.NEW_ADMISSION)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_PRISONER_BALANCE_RESET), anyMap())
-    verify(changeLogService).findChangeLogForPrisonerByType(dpsPrisoner.prisonerId, ChangeLogType.PRISONER_BALANCE_RESET)
   }
 
   private fun createPrisonerDto(prisonerId: String, prisonId: String = "MDI", inOutStatus: String = "IN", lastPrisonId: String = "HEI"): PrisonerDto = PrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = inOutStatus, lastPrisonId = lastPrisonId)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -106,7 +106,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 
   /**
@@ -148,7 +147,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN - 2 Visit orders should be generated (2 VOs but no PVOs).
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 
   /**
@@ -189,7 +187,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 
   /**
@@ -219,7 +216,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 
   /**
@@ -261,7 +257,6 @@ class ProcessPrisonerServiceTest {
 
     // THEN
     verify(incentivesClient).getPrisonerIncentiveReviewHistory(prisonerId)
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
   }
 
   // Prisoner VO Usage By Visit \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -338,10 +338,8 @@ class ProcessPrisonerServiceTest {
     processPrisonerService.processPrisonerVisitOrderRefund(visit)
 
     // THEN
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
     verify(changeLogService).createLogAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_REFUNDED_AFTER_VISIT_CANCELLATION), anyMap())
-    verify(changeLogService).findChangeLogForPrisonerByType(dpsPrisoner.prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)
   }
 
   // Prisoner Reset balance \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -299,10 +299,8 @@ class ProcessPrisonerServiceTest {
     processPrisonerService.processPrisonerVisitOrderUsage(visit)
 
     // THEN
-    verify(prisonerDetailsService).updatePrisonerDetails(dpsPrisoner)
     verify(changeLogService).createLogAllocationUsedByVisit(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_CONSUMED_BY_VISIT), anyMap())
-    verify(changeLogService).findChangeLogForPrisonerByType(dpsPrisoner.prisonerId, ChangeLogType.ALLOCATION_USED_BY_VISIT)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryServ
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.TelemetryClientService
 import java.time.LocalDate
+import java.util.*
 
 @ExtendWith(MockitoExtension::class)
 class ProcessPrisonerServiceTest {
@@ -89,6 +90,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -130,6 +132,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -170,6 +173,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -241,6 +245,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -283,6 +288,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -323,6 +329,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN
@@ -362,6 +369,7 @@ class ProcessPrisonerServiceTest {
       prisoner = dpsPrisoner,
       visitOrderBalance = dpsPrisoner.getVoBalance(),
       privilegedVisitOrderBalance = dpsPrisoner.getPvoBalance(),
+      reference = UUID.randomUUID(),
     )
 
     // WHEN

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerGetAdjustmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerGetAdjustmentTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.integration.helper.callGe
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import java.time.LocalDate
+import java.util.*
 
 @DisplayName("NomisController get prisoner adjustment tests - $VO_GET_PRISONER_ADJUSTMENT")
 class NomisControllerGetAdjustmentTest : IntegrationTestBase() {
@@ -38,6 +39,7 @@ class NomisControllerGetAdjustmentTest : IntegrationTestBase() {
         visitOrderBalance = 5,
         privilegedVisitOrderBalance = 2,
         prisoner = prisoner,
+        reference = UUID.randomUUID(),
       ),
     )
 
@@ -51,6 +53,7 @@ class NomisControllerGetAdjustmentTest : IntegrationTestBase() {
         visitOrderBalance = 7,
         privilegedVisitOrderBalance = 3,
         prisoner = prisoner,
+        reference = UUID.randomUUID(),
       ),
     ).id
 
@@ -81,6 +84,7 @@ class NomisControllerGetAdjustmentTest : IntegrationTestBase() {
         visitOrderBalance = 7,
         privilegedVisitOrderBalance = 3,
         prisoner = prisoner,
+        reference = UUID.randomUUID(),
       ),
     ).id
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDeta
 import uk.gov.justice.hmpps.sqs.countMessagesOnQueue
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.util.*
 
 @DisplayName("Test for Domain Event Visit Booked")
 class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
@@ -51,6 +52,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -108,6 +110,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -164,6 +167,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -223,6 +227,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -272,6 +277,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -321,6 +327,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -367,6 +374,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
@@ -28,6 +28,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.temporal.TemporalAdjusters
+import java.util.*
 
 @DisplayName("Test for Domain Event Visit Cancelled")
 class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
@@ -64,6 +65,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -131,6 +133,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -198,6 +201,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -307,6 +311,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -361,6 +366,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
@@ -415,6 +421,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
         prisoner = dpsPrisoner,
         visitOrderBalance = 2,
         privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
       ),
     )
     prisonerDetailsRepository.saveAndFlush(dpsPrisoner)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -52,7 +52,7 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { prisonVisitsAllocationPrisonerRetryQueueSqsClient.countMessagesOnQueue(prisonVisitsAllocationPrisonerRetryQueueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(visitAllocationPrisonerRetryQueueListenerSpy, times(1)).processMessage(visitAllocationPrisonerRetryJob) }
-    await untilAsserted { verify(prisonerDetailsRepository, times(2)).saveAndFlush(any()) }
+    await untilAsserted { verify(prisonerDetailsRepository, times(1)).saveAndFlush(any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
     val visitOrders = visitOrderRepository.findAll()


### PR DESCRIPTION
## What does this PR do?
Remove the manual call to save the updated prisoner details, as this was overwriting hibernates management of the entity and causing data to be wiped if two requests came in at the same time.

## Part 1 PR
https://github.com/ministryofjustice/hmpps-visit-allocation-api/pull/118