### PR TITLE
Move prisoner creation into isolated transaction

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
@@ -18,8 +18,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocation
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerAdjustmentResponseDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerMigrationDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncDto
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisMigrationService
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisService
 import uk.gov.justice.hmpps.kotlin.common.ErrorResponse
 
 const val VO_NOMIS = "/visits/allocation/prisoner"
@@ -31,8 +30,7 @@ const val VO_GET_PRISONER_ADJUSTMENT = "$VO_NOMIS/{prisonerId}/adjustments/{adju
 
 @RestController
 class NomisController(
-  val nomisMigrationService: NomisMigrationService,
-  val nomisSyncService: NomisSyncService,
+  val nomisService: NomisService,
 ) {
   @PreAuthorize("hasRole('$ROLE_VISIT_ALLOCATION_API__NOMIS_API')")
   @PostMapping(VO_PRISONER_MIGRATION)
@@ -57,7 +55,7 @@ class NomisController(
     ],
   )
   fun migratePrisonerVisitOrders(@RequestBody @Valid visitAllocationPrisonerMigrationDto: VisitAllocationPrisonerMigrationDto): ResponseEntity<Void> {
-    nomisMigrationService.migratePrisoner(visitAllocationPrisonerMigrationDto)
+    nomisService.processMigrationRequest(visitAllocationPrisonerMigrationDto)
     return ResponseEntity.status(HttpStatus.OK).build()
   }
 
@@ -84,7 +82,7 @@ class NomisController(
     ],
   )
   fun syncPrisonerVisitOrders(@RequestBody @Valid visitAllocationPrisonerSyncDto: VisitAllocationPrisonerSyncDto): ResponseEntity<Void> {
-    nomisSyncService.syncPrisonerAdjustmentChanges(visitAllocationPrisonerSyncDto)
+    nomisService.processSyncRequest(visitAllocationPrisonerSyncDto)
     return ResponseEntity.status(HttpStatus.OK).build()
   }
 
@@ -122,5 +120,5 @@ class NomisController(
     @Schema(description = "adjustmentId", example = "1234", required = true)
     @PathVariable
     adjustmentId: String,
-  ): VisitAllocationPrisonerAdjustmentResponseDto = nomisSyncService.getChangeLogForNomis(VisitAllocationPrisonerAdjustmentRequestDto(prisonerId, adjustmentId.toLong()))
+  ): VisitAllocationPrisonerAdjustmentResponseDto = nomisService.getChangeLogForNomis(VisitAllocationPrisonerAdjustmentRequestDto(prisonerId, adjustmentId.toLong()))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -15,6 +15,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import kotlin.math.abs
 
+@Transactional
 @Service
 class NomisMigrationService(
   private val changeLogService: ChangeLogService,
@@ -25,7 +26,6 @@ class NomisMigrationService(
     const val NULL_LAST_ALLOCATION_DATE_OFFSET = 28L
   }
 
-  @Transactional
   fun migratePrisoner(migrationDto: VisitAllocationPrisonerMigrationDto) {
     LOG.info("Entered NomisMigrationService - migratePrisoner with migration dto {}", migrationDto)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisService.kt
@@ -1,0 +1,63 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.service
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerAdjustmentRequestDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerAdjustmentResponseDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerMigrationDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.nomis.VisitAllocationPrisonerSyncDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
+
+@Service
+class NomisService(
+  private val nomisSyncService: NomisSyncService,
+  private val nomisMigrationService: NomisMigrationService,
+  private val prisonerDetailsService: PrisonerDetailsService,
+  private val changeLogService: ChangeLogService,
+) {
+  companion object {
+    val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun processSyncRequest(syncDto: VisitAllocationPrisonerSyncDto) {
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(syncDto.prisonerId)
+    if (dpsPrisoner == null) {
+      prisonerDetailsService.createPrisonerDetails(syncDto.prisonerId, syncDto.createdDate, null)
+    }
+
+    nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
+  }
+
+  fun processMigrationRequest(migrationDto: VisitAllocationPrisonerMigrationDto) {
+    nomisMigrationService.migratePrisoner(migrationDto)
+  }
+
+  fun getChangeLogForNomis(requestDto: VisitAllocationPrisonerAdjustmentRequestDto): VisitAllocationPrisonerAdjustmentResponseDto {
+    val prisonerChangeLogs = changeLogService.findAllChangeLogsForPrisoner(requestDto.prisonerId).sortedBy { it.id }
+
+    val currentIndex = prisonerChangeLogs.indexOfFirst { it.id == requestDto.changeLogId }
+    if (currentIndex == -1) {
+      throw NotFoundException("Change log with ID ${requestDto.changeLogId} not found for prisoner ${requestDto.prisonerId}")
+    }
+
+    val currentEntry = prisonerChangeLogs[currentIndex]
+    val previousEntry = if (currentIndex > 0) prisonerChangeLogs[currentIndex - 1] else null
+
+    val previousVoBalance = previousEntry?.visitOrderBalance ?: 0
+    val previousPvoBalance = previousEntry?.privilegedVisitOrderBalance ?: 0
+
+    return VisitAllocationPrisonerAdjustmentResponseDto(
+      prisonerId = requestDto.prisonerId,
+      voBalance = previousVoBalance,
+      changeToVoBalance = currentEntry.visitOrderBalance - previousVoBalance,
+      pvoBalance = previousPvoBalance,
+      changeToPvoBalance = currentEntry.privilegedVisitOrderBalance - previousPvoBalance,
+      changeLogType = currentEntry.changeType,
+      userId = currentEntry.userId,
+      changeLogSource = currentEntry.changeSource,
+      changeTimestamp = currentEntry.changeTimestamp,
+      comment = currentEntry.comment,
+    )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -93,29 +93,20 @@ class NomisSyncService(
       }
     }
 
-    var dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)
-    val prisonerDpsBalance: PrisonerBalanceDto
-    if (dpsPrisoner == null) {
-      val lastVoAllocatedDate = prisonerNomisBalance.latestIepAdjustDate ?: LocalDate.now()
-      // If they're new, onboard them by saving their details in the prisoner_details table and init their balance.
-      dpsPrisoner = prisonerDetailsService.createPrisonerDetails(prisonerId, lastVoAllocatedDate, prisonerNomisBalance.latestPrivIepAdjustDate)
-      prisonerDpsBalance = PrisonerBalanceDto(prisonerId, 0, 0)
-    } else {
-      prisonerDpsBalance = dpsPrisoner.getBalance()
-    }
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)!!
 
-    val voBalanceChange = (prisonerNomisBalance.remainingVo - prisonerDpsBalance.voBalance)
+    val voBalanceChange = (prisonerNomisBalance.remainingVo - dpsPrisoner.getVoBalance())
     processSync(
       prisoner = dpsPrisoner,
-      prisonerDpsBalance = prisonerDpsBalance.voBalance,
+      prisonerDpsBalance = dpsPrisoner.getVoBalance(),
       balanceChange = voBalanceChange,
       visitOrderType = VisitOrderType.VO,
     )
 
-    val pvoBalanceChange = (prisonerNomisBalance.remainingPvo - prisonerDpsBalance.pvoBalance)
+    val pvoBalanceChange = (prisonerNomisBalance.remainingPvo - dpsPrisoner.getPvoBalance())
     processSync(
       prisoner = dpsPrisoner,
-      prisonerDpsBalance = prisonerDpsBalance.pvoBalance,
+      prisonerDpsBalance = dpsPrisoner.getPvoBalance(),
       balanceChange = pvoBalanceChange,
       visitOrderType = VisitOrderType.PVO,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -18,7 +18,7 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId, newLastAllocatedDate - $newLastAllocatedDate and newLastPvoAllocatedDate - $newLastPvoAllocatedDate")
-    return prisonerDetailsRepository.saveAndFlush(
+    return prisonerDetailsRepository.save(
       PrisonerDetails(
         prisonerId = prisonerId,
         lastVoAllocatedDate = newLastAllocatedDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -42,8 +42,7 @@ class ProcessPrisonerService(
 
   @Transactional
   fun processPrisonerVisitOrderUsage(visit: VisitDto): UUID {
-    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)
-      ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
+    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)!!
 
     // Find the oldest PVO to use. If none exists, find the oldest VO to use.
     val selected: VisitOrder? = dpsPrisonerDetails.visitOrders
@@ -89,8 +88,7 @@ class ProcessPrisonerService(
 
   @Transactional
   fun processPrisonerVisitOrderRefund(visit: VisitDto): UUID {
-    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)
-      ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
+    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)!!
 
     // Find the VO used by the visit.
     val voUsedForVisit: VisitOrder? = dpsPrisonerDetails.visitOrders.firstOrNull { it.visitReference == visit.reference }
@@ -134,8 +132,7 @@ class ProcessPrisonerService(
     var privilegedVisitOrdersToBeCreated = 0
 
     LOG.info("processPrisonerMerge with newPrisonerId - $newPrisonerId and removedPrisonerId - $removedPrisonerId")
-    val newPrisonerDetails = prisonerDetailsService.getPrisonerDetails(newPrisonerId) ?: prisonerDetailsService.createPrisonerDetails(newPrisonerId, LocalDate.now().minusDays(14), null)
-
+    val newPrisonerDetails = prisonerDetailsService.getPrisonerDetails(newPrisonerId)!!
     val removedPrisonerDetails = prisonerDetailsService.getPrisonerDetails(removedPrisonerId)
 
     if (removedPrisonerDetails != null) {
@@ -189,8 +186,7 @@ class ProcessPrisonerService(
 
   @Transactional
   fun processPrisonerReceivedResetBalance(prisonerId: String, reason: PrisonerReceivedReasonType): UUID {
-    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisonerId)
-      ?: prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    val dpsPrisonerDetails: PrisonerDetails = prisonerDetailsService.getPrisonerDetails(prisonerId)!!
 
     dpsPrisonerDetails.visitOrders
       .filter { it.status in listOf(VisitOrderStatus.AVAILABLE, VisitOrderStatus.ACCUMULATED) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerBookingMovedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerBookingMovedEventHandler.kt
@@ -6,8 +6,10 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerBookingMovedInfo
+import java.time.LocalDate
 
 @Service
 class PrisonerBookingMovedEventHandler(
@@ -15,6 +17,7 @@ class PrisonerBookingMovedEventHandler(
   private val prisonService: PrisonService,
   private val prisonerSearchClient: PrisonerSearchClient,
   private val nomisSyncService: NomisSyncService,
+  private val prisonerDetailsService: PrisonerDetailsService,
 ) : DomainEventHandler {
 
   override fun handle(domainEvent: DomainEvent) {
@@ -32,6 +35,11 @@ class PrisonerBookingMovedEventHandler(
   }
 
   private fun processNomis(prisonerId: String) {
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)
+    if (dpsPrisoner == null) {
+      prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    }
+
     nomisSyncService.syncPrisonerBalanceFromEventChange(prisonerId, DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerMergedEventHandler.kt
@@ -53,6 +53,11 @@ class PrisonerMergedEventHandler(
 
   private fun processDps(info: PrisonerMergedInfo) {
     LOG.info("Handling DPS prison merge event - $info")
+    val newPrisonerDetails = prisonerDetailsService.getPrisonerDetails(info.prisonerId)
+    if (newPrisonerDetails == null) {
+      prisonerDetailsService.createPrisonerDetails(info.prisonerId, LocalDate.now().minusDays(14), null)
+    }
+
     val changeLogReference = processPrisonerService.processPrisonerMerge(info.prisonerId, info.removedPrisonerId)
     if (changeLogReference != null) {
       val changeLog = changeLogService.findChangeLogForPrisonerByReference(info.prisonerId, changeLogReference)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerReceivedEventHandler.kt
@@ -12,10 +12,12 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerRecei
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.SnsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerReceivedInfo
+import java.time.LocalDate
 
 @Service
 class PrisonerReceivedEventHandler(
@@ -25,6 +27,7 @@ class PrisonerReceivedEventHandler(
   private val processPrisonerService: ProcessPrisonerService,
   private val snsService: SnsService,
   private val changeLogService: ChangeLogService,
+  private val prisonerDetailsService: PrisonerDetailsService,
 ) : DomainEventHandler {
 
   companion object {
@@ -70,6 +73,11 @@ class PrisonerReceivedEventHandler(
   }
 
   private fun processNomis(info: PrisonerReceivedInfo) {
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(info.prisonerId)
+    if (dpsPrisoner == null) {
+      prisonerDetailsService.createPrisonerDetails(info.prisonerId, LocalDate.now().minusDays(14), null)
+    }
+
     nomisSyncService.syncPrisonerBalanceFromEventChange(info.prisonerId, DomainEventType.PRISONER_RECEIVED_EVENT_TYPE)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerReceivedEventHandler.kt
@@ -62,6 +62,11 @@ class PrisonerReceivedEventHandler(
   private fun processDps(info: PrisonerReceivedInfo) {
     if (shouldWipePrisonerBalance(info.reason)) {
       LOG.info("Prisoner ${info.prisonerId} received for reason ${info.reason}, wiping balance")
+      val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetails(info.prisonerId)
+      if (dpsPrisonerDetails == null) {
+        prisonerDetailsService.createPrisonerDetails(info.prisonerId, LocalDate.now().minusDays(14), null)
+      }
+
       val changeLogReference = processPrisonerService.processPrisonerReceivedResetBalance(info.prisonerId, info.reason)
       val changeLog = changeLogService.findChangeLogForPrisonerByReference(info.prisonerId, changeLogReference)
       if (changeLog != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/NomisControllerMigrateTest.kt
@@ -35,7 +35,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).save<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -64,7 +64,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(visitOrderRepository, times(0)).saveAll<VisitOrder>(any())
-    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).save<PrisonerDetails>(any())
 
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(7)
@@ -92,7 +92,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     // Then
     responseSpec.expectStatus().isOk
 
-    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).save<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(5)
@@ -126,7 +126,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(1)).save<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)
@@ -159,7 +159,7 @@ class NomisControllerMigrateTest : IntegrationTestBase() {
     responseSpec.expectStatus().isOk
 
     verify(negativeVisitOrderRepository, times(0)).saveAll<NegativeVisitOrder>(any())
-    verify(prisonerDetailsRepository, times(1)).saveAndFlush<PrisonerDetails>(any())
+    verify(prisonerDetailsRepository, times(2)).save<PrisonerDetails>(any())
 
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.size).isEqualTo(7)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -107,12 +107,12 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(3)
 
     val movedFromPrisonerDetails = prisonerDetailsRepository.findById(movedFromPrisonerId).get()
-    assertThat(movedFromPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
-    assertThat(movedFromPrisonerDetails.lastPvoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
+    assertThat(movedFromPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(14))
+    assertThat(movedFromPrisonerDetails.lastPvoAllocatedDate).isNull()
 
     val movedToPrisonerDetails = prisonerDetailsRepository.findById(movedToPrisonerId).get()
-    assertThat(movedToPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
-    assertThat(movedToPrisonerDetails.lastPvoAllocatedDate).isEqualTo(LocalDate.now().minusDays(1))
+    assertThat(movedToPrisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(14))
+    assertThat(movedToPrisonerDetails.lastPvoAllocatedDate).isNull()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerMergedTest.kt
@@ -162,7 +162,7 @@ class DomainEventsPrisonerMergedTest : EventsIntegrationTestBase() {
     val prisonerDetails = prisonerDetailsRepository.findAll()
     assertThat(prisonerDetails.size).isEqualTo(1)
     assertThat(prisonerDetails[0].prisonerId).isEqualTo(prisonerId)
-    assertThat(prisonerDetails[0].lastVoAllocatedDate).isEqualTo(LocalDate.now())
+    assertThat(prisonerDetails[0].lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(14))
     assertThat(prisonerDetails[0].lastPvoAllocatedDate).isNull()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsPrisonerReceivedTest.kt
@@ -190,7 +190,7 @@ class DomainEventsPrisonerReceivedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(5)
 
     val prisonerDetails = prisonerDetailsRepository.findById(prisonerId).get()
-    assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now())
+    assertThat(prisonerDetails.lastVoAllocatedDate).isEqualTo(LocalDate.now().minusDays(14))
     assertThat(prisonerDetails.lastPvoAllocatedDate).isNull()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/PrisonerRetryQueueHandlerTest.kt
@@ -52,7 +52,7 @@ class PrisonerRetryQueueHandlerTest : EventsIntegrationTestBase() {
     // Then
     await untilCallTo { prisonVisitsAllocationPrisonerRetryQueueSqsClient.countMessagesOnQueue(prisonVisitsAllocationPrisonerRetryQueueUrl).get() } matches { it == 0 }
     await untilAsserted { verify(visitAllocationPrisonerRetryQueueListenerSpy, times(1)).processMessage(visitAllocationPrisonerRetryJob) }
-    await untilAsserted { verify(prisonerDetailsRepository, times(1)).saveAndFlush(any()) }
+    await untilAsserted { verify(prisonerDetailsRepository, times(1)).save(any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
     val visitOrders = visitOrderRepository.findAll()


### PR DESCRIPTION
To avoid race conditions on inserting new prisoners, put the creation logic into it's own transaction.