### PR TITLE
Bug fixes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/ChangeLogRepository.kt
@@ -2,15 +2,12 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import java.util.*
 
 @Repository
 interface ChangeLogRepository : JpaRepository<ChangeLog, Long> {
   fun findAllByPrisonerId(prisonerId: String): List<ChangeLog>?
-
-  fun findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId: String, changeType: ChangeLogType): ChangeLog?
 
   fun findFirstByPrisonerIdAndReference(prisonerId: String, reference: UUID): ChangeLog?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ChangeLogService.kt
@@ -128,8 +128,6 @@ class ChangeLogService(val changeLogRepository: ChangeLogRepository) {
     return prisonerChangeLogs
   }
 
-  fun findChangeLogForPrisonerByType(prisonerId: String, changeLogType: ChangeLogType): ChangeLog? = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, changeLogType)
-
   fun findChangeLogForPrisonerByReference(prisonerId: String, reference: UUID): ChangeLog? = changeLogRepository.findFirstByPrisonerIdAndReference(prisonerId, reference)
 
   private fun createChangeLog(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/DomainEventListenerService.kt
@@ -11,6 +11,7 @@ class DomainEventListenerService(private val handlerRegistry: DomainEventHandler
   companion object {
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
+
   fun handleMessage(domainEvent: DomainEvent) {
     val handler = handlerRegistry.getHandler(domainEvent.eventType)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -153,7 +153,10 @@ class NomisSyncService(
       } else {
         val negativeVosToCreate = abs(prisonerDpsBalance + balanceChange)
         LOG.info("Balance decreased and is negative for prisoner ${prisoner.prisonerId}, expiring all $visitOrderType and creating $negativeVosToCreate $visitOrderType")
-        prisoner.visitOrders.filter { it.type == visitOrderType }.forEach { visitOrder -> visitOrder.status = VisitOrderStatus.EXPIRED }
+        prisoner.visitOrders.filter { it.type == visitOrderType }.forEach { visitOrder ->
+          visitOrder.status = VisitOrderStatus.EXPIRED
+          visitOrder.expiryDate = LocalDate.now()
+        }
         prisoner.negativeVisitOrders.addAll(createNegativeVisitOrders(prisoner, visitOrderType, negativeVosToCreate))
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -49,9 +49,11 @@ class VisitBookedEventHandler(
         }
 
         val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit)
-        val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
-        if (changeLog != null) {
-          snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
+        if (changeLogReference != null) {
+          val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
+          if (changeLog != null) {
+            snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
+          }
         }
       } else {
         LOG.info("Prisoner ${visit.prisonerId} is on Remand, no processing needed")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
@@ -57,7 +57,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     dpsPrisoner.changeLogs.add(
       ChangeLog(
         changeTimestamp = LocalDateTime.now().minusSeconds(1),
-        changeType = ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
+        changeType = ChangeLogType.BATCH_PROCESS,
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         prisonerId = dpsPrisoner.prisonerId,
@@ -97,7 +97,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.first { it.type == VisitOrderType.PVO }.createdTimestamp).isEqualTo(LocalDateTime.now().with(TemporalAdjusters.firstDayOfMonth()).with(LocalTime.MIN))
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
 
-    val changLog = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)!!
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
     assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
   }
 
@@ -125,7 +125,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     dpsPrisoner.changeLogs.add(
       ChangeLog(
         changeTimestamp = LocalDateTime.now().minusSeconds(1),
-        changeType = ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
+        changeType = ChangeLogType.BATCH_PROCESS,
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         prisonerId = dpsPrisoner.prisonerId,
@@ -165,7 +165,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.first { it.type == VisitOrderType.VO }.createdTimestamp.toLocalDate()).isEqualTo(LocalDate.now().minusDays(1))
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
 
-    val changLog = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)!!
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
     assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
   }
 
@@ -193,7 +193,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     dpsPrisoner.changeLogs.add(
       ChangeLog(
         changeTimestamp = LocalDateTime.now().minusSeconds(1),
-        changeType = ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
+        changeType = ChangeLogType.BATCH_PROCESS,
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         prisonerId = dpsPrisoner.prisonerId,
@@ -234,7 +234,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(0)
 
-    val changLog = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)!!
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
     assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
   }
 
@@ -275,7 +275,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findFirstByPrisonerIdAndChangeTypeOrderByChangeTimestampDesc(prisonerId, ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED)!!
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
     assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
   }
 
@@ -303,7 +303,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     dpsPrisoner.changeLogs.add(
       ChangeLog(
         changeTimestamp = LocalDateTime.now().minusSeconds(1),
-        changeType = ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
+        changeType = ChangeLogType.BATCH_PROCESS,
         changeSource = ChangeLogSource.SYSTEM,
         userId = "SYSTEM",
         prisonerId = dpsPrisoner.prisonerId,


### PR DESCRIPTION
## What does this PR do?
Fix the possiblity that our SQS "at least once delivery" queue, can provide the service with the same message twice if something goes wrong on AWS side. Added a check on visit-booked event, to not re-process the same message if another VO is already mapped to the visit.

Fixed some spacing issues