### PR TITLE
Bug - Handle incentive endpoint failing gracefully

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/IncentivesClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/IncentivesClient.kt
@@ -32,7 +32,7 @@ class IncentivesClient(
       .block() ?: throw TimeoutException("Request timed out while fetching prisoner incentive level for prisoner ID $prisonerId")
   }
 
-  fun getPrisonIncentiveLevels(prisonId: String): List<PrisonIncentiveAmountsDto> {
+  fun getPrisonIncentiveLevels(prisonId: String): List<PrisonIncentiveAmountsDto>? {
     LOG.info("Calling incentives-api to get prison all incentive levels for prison $prisonId")
 
     val uri = "/incentive/prison-levels/$prisonId"
@@ -41,15 +41,10 @@ class IncentivesClient(
       .retrieve()
       .bodyToMono<List<PrisonIncentiveAmountsDto>>()
       .onErrorResume { e ->
-        if (!isNotFoundError(e)) {
-          LOG.error("getPrisonIncentiveLevels Failed for get request $uri")
-          Mono.error(e)
-        } else {
-          LOG.error("getPrisonIncentiveLevels NOT_FOUND for get request $uri")
-          Mono.error { NotFoundException("Incentive levels not found for prison $prisonId, $e") }
-        }
+        LOG.error("getPrisonIncentiveLevels failed for get request $uri, returning null")
+        Mono.empty()
       }
-      .block() ?: throw TimeoutException("Request timed out while fetching incentive levels for $prisonId")
+      .block()
   }
 
   fun getPrisonIncentiveLevelByLevelCode(prisonId: String, levelCode: String): PrisonIncentiveAmountsDto {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/PrisonerBalanceDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/PrisonerBalanceDto.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.dto
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PrisonerBalanceDto(
-  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
   val prisonerId: String,
 
-  @Schema(description = "The current VO balance (can be negative)", example = "5", required = true)
+  @field:Schema(description = "The current VO balance (can be negative)", example = "5", required = true)
   val voBalance: Int,
 
-  @Schema(description = "The current PVO balance (can be negative)", example = "2", required = true)
+  @field:Schema(description = "The current PVO balance (can be negative)", example = "2", required = true)
   val pvoBalance: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/incentives/PrisonIncentiveAmountsDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/incentives/PrisonIncentiveAmountsDto.kt
@@ -3,12 +3,12 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PrisonIncentiveAmountsDto(
-  @Schema(required = true, description = "Incentive level code", example = "STD")
+  @field:Schema(required = true, description = "Incentive level code", example = "STD")
   val levelCode: String,
 
-  @Schema(required = true, description = "Incentive bonus for visit orders", example = "1")
+  @field:Schema(required = true, description = "Incentive bonus for visit orders", example = "1")
   val visitOrders: Int,
 
-  @Schema(required = true, description = "Incentive bonus for privileged visit orders", example = "2")
+  @field:Schema(required = true, description = "Incentive bonus for privileged visit orders", example = "2")
   val privilegedVisitOrders: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/incentives/PrisonerIncentivesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/incentives/PrisonerIncentivesDto.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PrisonerIncentivesDto(
-  @Schema(required = true, description = "Incentive level code", example = "STD")
+  @field:Schema(required = true, description = "Incentive level code", example = "STD")
   val iepCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/jobs/VisitAllocationEventJobDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/jobs/VisitAllocationEventJobDto.kt
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotNull
 
 data class VisitAllocationEventJobDto(
-  @Schema(description = "Visit Allocation Job Reference", example = "aa-bb-cc-dd", required = true)
+  @field:Schema(description = "Visit Allocation Job Reference", example = "aa-bb-cc-dd", required = true)
   @field:NotNull
   val allocationJobReference: String,
 
-  @Schema(description = "Number of active prisons", example = "12", required = true)
+  @field:Schema(description = "Number of active prisons", example = "12", required = true)
   @field:NotNull
   val totalActivePrisons: Int = 0,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentRequestDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentRequestDto.kt
@@ -5,12 +5,12 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 
 data class VisitAllocationPrisonerAdjustmentRequestDto(
-  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
   @field:NotNull
   @field:NotEmpty
   val prisonerId: String,
 
-  @Schema(description = "The change log (adjustments) ID", example = "123456", required = true)
+  @field:Schema(description = "The change log (adjustments) ID", example = "123456", required = true)
   @field:NotNull
   val changeLogId: Long,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerAdjustmentResponseDto.kt
@@ -6,33 +6,33 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSour
 import java.time.LocalDateTime
 
 data class VisitAllocationPrisonerAdjustmentResponseDto(
-  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
   val prisonerId: String,
 
-  @Schema(description = "previous VO balance of prisoner (can be negative)", example = "2", required = false)
+  @field:Schema(description = "previous VO balance of prisoner (can be negative)", example = "2", required = false)
   val voBalance: Int?,
 
-  @Schema(description = "change to previous VO balance (can be negative)", example = "-1", required = false)
+  @field:Schema(description = "change to previous VO balance (can be negative)", example = "-1", required = false)
   val changeToVoBalance: Int?,
 
-  @Schema(description = "previous PVO balance of prisoner (can be negative)", example = "1", required = false)
+  @field:Schema(description = "previous PVO balance of prisoner (can be negative)", example = "1", required = false)
   val pvoBalance: Int?,
 
-  @Schema(description = "change to previous PVO balance (can be negative)", example = "-1", required = false)
+  @field:Schema(description = "change to previous PVO balance (can be negative)", example = "-1", required = false)
   val changeToPvoBalance: Int?,
 
-  @Schema(description = "type of change applied", example = "SYNC", required = true)
+  @field:Schema(description = "type of change applied", example = "SYNC", required = true)
   val changeLogType: ChangeLogType,
 
-  @Schema(description = "user who applied change [If system -> SYSTEM, if user -> username]", example = "JSMITH", required = true)
+  @field:Schema(description = "user who applied change [If system -> SYSTEM, if user -> username]", example = "JSMITH", required = true)
   val userId: String,
 
-  @Schema(description = "source of change applied", example = "'STAFF' / 'SYSTEM'", required = true)
+  @field:Schema(description = "source of change applied", example = "'STAFF' / 'SYSTEM'", required = true)
   val changeLogSource: ChangeLogSource,
 
-  @Schema(description = "Timestamp of when change occurred", required = true)
+  @field:Schema(description = "Timestamp of when change occurred", required = true)
   val changeTimestamp: LocalDateTime,
 
-  @Schema(description = "additional information of change applied", example = "Gave prisoner extra VO", required = false)
+  @field:Schema(description = "additional information of change applied", example = "Gave prisoner extra VO", required = false)
   val comment: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerMigrationDto.kt
@@ -6,19 +6,19 @@ import jakarta.validation.constraints.NotNull
 import java.time.LocalDate
 
 data class VisitAllocationPrisonerMigrationDto(
-  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
   @field:NotNull
   @field:NotEmpty
   val prisonerId: String,
 
-  @Schema(description = "The current VO balance (can be negative)", example = "5", required = true)
+  @field:Schema(description = "The current VO balance (can be negative)", example = "5", required = true)
   @field:NotNull
   val voBalance: Int,
 
-  @Schema(description = "The current PVO balance (can be negative)", example = "2", required = true)
+  @field:Schema(description = "The current PVO balance (can be negative)", example = "2", required = true)
   @field:NotNull
   val pvoBalance: Int,
 
-  @Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = false)
+  @field:Schema(description = "The date which the last iep allocation was given", example = "2025-02-28", required = false)
   var lastVoAllocationDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncBookingDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncBookingDto.kt
@@ -6,25 +6,25 @@ import jakarta.validation.constraints.NotNull
 
 @Schema(description = "DTO to provide information of 2 prisoners effected by a booking moved between them in NOMIS")
 data class VisitAllocationPrisonerSyncBookingDto(
-  @Schema(description = "nomsNumber of the first prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the first prisoner", example = "AA123456", required = true)
   @field:NotNull
   @field:NotEmpty
   val firstPrisonerId: String,
 
-  @Schema(description = "The new VO balance of the first prisoner (can be negative)", example = "5", required = true)
+  @field:Schema(description = "The new VO balance of the first prisoner (can be negative)", example = "5", required = true)
   val firstPrisonerVoBalance: Int,
 
-  @Schema(description = "The new PVO balance of the first prisoner (can be negative)", example = "1", required = true)
+  @field:Schema(description = "The new PVO balance of the first prisoner (can be negative)", example = "1", required = true)
   val firstPrisonerPvoBalance: Int,
 
-  @Schema(description = "nomsNumber of the second prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the second prisoner", example = "AA123456", required = true)
   @field:NotNull
   @field:NotEmpty
   val secondPrisonerId: String,
 
-  @Schema(description = "The new VO balance of the second prisoner (can be negative)", example = "5", required = true)
+  @field:Schema(description = "The new VO balance of the second prisoner (can be negative)", example = "5", required = true)
   val secondPrisonerVoBalance: Int,
 
-  @Schema(description = "The new PVO balance of the second prisoner (can be negative)", example = "1", required = true)
+  @field:Schema(description = "The new PVO balance of the second prisoner (can be negative)", example = "1", required = true)
   val secondPrisonerPvoBalance: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/nomis/VisitAllocationPrisonerSyncDto.kt
@@ -8,35 +8,35 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSour
 import java.time.LocalDate
 
 data class VisitAllocationPrisonerSyncDto(
-  @Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
+  @field:Schema(description = "nomsNumber of the prisoner", example = "AA123456", required = true)
   @field:NotNull
   @field:NotEmpty
   val prisonerId: String,
 
-  @Schema(description = "The previous VO balance (can be negative)", example = "5", required = false)
+  @field:Schema(description = "The previous VO balance (can be negative)", example = "5", required = false)
   val oldVoBalance: Int? = null,
 
-  @Schema(description = "The change of the VO balance (can be negative)", example = "5", required = false)
+  @field:Schema(description = "The change of the VO balance (can be negative)", example = "5", required = false)
   val changeToVoBalance: Int? = null,
 
-  @Schema(description = "The previous PVO balance (can be negative)", example = "2", required = false)
+  @field:Schema(description = "The previous PVO balance (can be negative)", example = "2", required = false)
   val oldPvoBalance: Int? = null,
 
-  @Schema(description = "The change of the PVO balance (can be negative)", example = "5", required = false)
+  @field:Schema(description = "The change of the PVO balance (can be negative)", example = "5", required = false)
   val changeToPvoBalance: Int? = null,
 
-  @Schema(description = "The date which the change was made", example = "2025-02-28", required = true)
+  @field:Schema(description = "The date which the change was made", example = "2025-02-28", required = true)
   @field:NotNull
   val createdDate: LocalDate,
 
-  @Schema(description = "The reason for the adjustment", example = "VO_ISSUE", required = true)
+  @field:Schema(description = "The reason for the adjustment", example = "VO_ISSUE", required = true)
   @field:NotNull
   val adjustmentReasonCode: AdjustmentReasonCode,
 
-  @Schema(description = "The source of the change being made", example = "SYSTEM or STAFF", required = true)
+  @field:Schema(description = "The source of the change being made", example = "SYSTEM or STAFF", required = true)
   @field:NotNull
   val changeLogSource: ChangeLogSource,
 
-  @Schema(description = "Additional information on the sync reason", example = "Manually adjusted for phone credit", required = false)
+  @field:Schema(description = "Additional information on the sync reason", example = "Manually adjusted for phone credit", required = false)
   val comment: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prison/api/ServicePrisonDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prison/api/ServicePrisonDto.kt
@@ -4,9 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema
 
 @Schema(description = "Balances of visit orders and privilege visit orders")
 data class ServicePrisonDto(
-  @Schema(description = "Prison Code", example = "MDI", required = true)
+  @field:Schema(description = "Prison Code", example = "MDI", required = true)
   val agencyId: String,
 
-  @Schema(description = "Prison name", example = "Moorland (HMP)", required = true)
+  @field:Schema(description = "Prison name", example = "Moorland (HMP)", required = true)
   val name: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prison/api/VisitBalancesDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prison/api/VisitBalancesDto.kt
@@ -5,15 +5,15 @@ import java.time.LocalDate
 
 @Schema(description = "Balances of visit orders and privilege visit orders")
 data class VisitBalancesDto(
-  @Schema(required = true, description = "Balance of visit orders remaining")
+  @field:Schema(required = true, description = "Balance of visit orders remaining")
   val remainingVo: Int,
 
-  @Schema(required = true, description = "Balance of privilege visit orders remaining")
+  @field:Schema(required = true, description = "Balance of privilege visit orders remaining")
   val remainingPvo: Int,
 
-  @Schema(required = false, description = "Date of last IEP allocation")
+  @field:Schema(required = false, description = "Date of last IEP allocation")
   val latestIepAdjustDate: LocalDate?,
 
-  @Schema(required = false, description = "Date of last Priv IEP allocation")
+  @field:Schema(required = false, description = "Date of last Priv IEP allocation")
   val latestPrivIepAdjustDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prisoner/search/PrisonerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prisoner/search/PrisonerDto.kt
@@ -4,19 +4,19 @@ import com.fasterxml.jackson.annotation.JsonAlias
 import io.swagger.v3.oas.annotations.media.Schema
 
 data class PrisonerDto(
-  @Schema(required = true, description = "Prisoner Number", example = "A1234AA")
+  @field:Schema(required = true, description = "Prisoner Number", example = "A1234AA")
   @JsonAlias("prisonerNumber")
   val prisonerId: String,
 
-  @Schema(description = "Prison ID", example = "MDI")
+  @field:Schema(description = "Prison ID", example = "MDI")
   val prisonId: String,
 
-  @Schema(description = "In / out status of prisoner", example = "IN")
+  @field:Schema(description = "In / out status of prisoner", example = "IN")
   val inOutStatus: String,
 
-  @Schema(description = "Last prison ID of the prisoner", example = "IN")
+  @field:Schema(description = "Last prison ID of the prisoner", example = "IN")
   val lastPrisonId: String,
 
-  @Schema(description = "Convicted Status", example = "Convicted", allowableValues = ["Convicted", "Remand"])
+  @field:Schema(description = "Convicted Status", example = "Convicted", allowableValues = ["Convicted", "Remand"])
   val convictedStatus: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
@@ -8,12 +8,12 @@ import io.swagger.v3.oas.annotations.media.Schema
 @Schema(description = "Visit")
 @JsonInclude(JsonInclude.Include.NON_NULL)
 class VisitDto(
-  @Schema(description = "Visit Reference", example = "v9-d7-ed-7u", required = true)
+  @field:Schema(description = "Visit Reference", example = "v9-d7-ed-7u", required = true)
   val reference: String,
-  @Schema(description = "Prisoner Id", example = "AF34567G", required = true)
+  @field:Schema(description = "Prisoner Id", example = "AF34567G", required = true)
   val prisonerId: String,
   @JsonProperty("prisonId")
   @JsonAlias("prisonCode")
-  @Schema(description = "Prison Id", example = "MDI", required = true)
+  @field:Schema(description = "Prison Id", example = "MDI", required = true)
   val prisonCode: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -6,7 +6,6 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
-import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
 
 @Transactional
@@ -28,7 +27,7 @@ class AllocationService(
     prisonService.setVisitOrderAllocationPrisonJobStartTime(jobReference, prisonId)
 
     val allPrisoners = getConvictedPrisonersForPrison(jobReference = jobReference, prisonId = prisonId)
-    val allIncentiveLevels = getIncentiveLevelsForPrison(jobReference = jobReference, prisonId = prisonId)
+    val allIncentiveLevels = incentivesClient.getPrisonIncentiveLevels(prisonId = prisonId)
     var totalConvictedPrisonersProcessed = 0
     var totalConvictedPrisonersFailedOrSkipped = 0
 
@@ -73,18 +72,5 @@ class AllocationService(
     }
 
     return convictedPrisonersForPrison
-  }
-
-  private fun getIncentiveLevelsForPrison(jobReference: String, prisonId: String): List<PrisonIncentiveAmountsDto> {
-    val incentiveLevelsForPrison = try {
-      incentivesClient.getPrisonIncentiveLevels(prisonId)
-    } catch (e: Exception) {
-      val failureMessage = "failed to get incentive levels by prisonId - $prisonId"
-      LOG.error(failureMessage, e)
-      prisonService.setVisitOrderAllocationPrisonJobEndTimeAndFailureMessage(jobReference, prisonId, failureMessage)
-      throw e
-    }
-
-    return incentiveLevelsForPrison
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -225,7 +225,7 @@ class ProcessPrisonerService(
   }
 
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  fun processPrisonerAllocation(prisonerId: String, jobReference: String, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>, fromRetryQueue: Boolean? = false): UUID? {
+  fun processPrisonerAllocation(prisonerId: String, jobReference: String, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>?, fromRetryQueue: Boolean? = false): UUID? {
     LOG.info("Entered ProcessPrisonerService - processPrisoner for prisoner - $prisonerId")
 
     try {
@@ -276,13 +276,13 @@ class ProcessPrisonerService(
     return voChanged || nvoChanged
   }
 
-  private fun processPrisonerAllocation(dpsPrisoner: PrisonerDetails, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>) {
+  private fun processPrisonerAllocation(dpsPrisoner: PrisonerDetails, allPrisonIncentiveAmounts: List<PrisonIncentiveAmountsDto>?) {
     LOG.info("Entered ProcessPrisonerService - processPrisonerAllocation with prisonerId ${dpsPrisoner.prisonerId}")
 
     val prisonerPrisonId = prisonerSearchClient.getPrisonerById(dpsPrisoner.prisonerId).prisonId
     val prisonerIncentive = incentivesClient.getPrisonerIncentiveReviewHistory(dpsPrisoner.prisonerId)
 
-    val prisonIncentiveAmounts = allPrisonIncentiveAmounts.firstOrNull { it.levelCode == prisonerIncentive.iepCode }
+    val prisonIncentiveAmounts = allPrisonIncentiveAmounts?.firstOrNull { it.levelCode == prisonerIncentive.iepCode }
       ?: incentivesClient.getPrisonIncentiveLevelByLevelCode(prisonerPrisonId, prisonerIncentive.iepCode)
 
     val visitOrders = mutableListOf<VisitOrder>()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/DomainEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/DomainEvent.kt
@@ -5,10 +5,10 @@ import jakarta.validation.constraints.NotBlank
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.deserializers.RawJsonDeserializer
 
 data class DomainEvent(
-  @NotBlank
+  @field:NotBlank
   val eventType: String,
 
   @JsonDeserialize(using = RawJsonDeserializer::class)
-  @NotBlank
+  @field:NotBlank
   val additionalInformation: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/SQSMessage.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/SQSMessage.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 
 data class SQSMessage(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("Type")
   val type: String,
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("Message")
   val message: String,
   @JsonProperty("MessageId")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerBookingMovedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerBookingMovedInfo.kt
@@ -3,9 +3,9 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.
 import jakarta.validation.constraints.NotBlank
 
 data class PrisonerBookingMovedInfo(
-  @NotBlank
+  @field:NotBlank
   val movedFromNomsNumber: String,
 
-  @NotBlank
+  @field:NotBlank
   val movedToNomsNumber: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerConvictionStatusChangedInfo.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 
 data class PrisonerConvictionStatusChangedInfo(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("nomsNumber")
   val prisonerId: String,
 
-  @NotBlank
+  @field:NotBlank
   val convictedStatus: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerMergedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerMergedInfo.kt
@@ -4,11 +4,11 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import jakarta.validation.constraints.NotBlank
 
 data class PrisonerMergedInfo(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("nomsNumber")
   val prisonerId: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("removedNomsNumber")
   val removedPrisonerId: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerReceivedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/PrisonerReceivedInfo.kt
@@ -6,11 +6,11 @@ import jakarta.validation.constraints.NotNull
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 
 data class PrisonerReceivedInfo(
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("nomsNumber")
   val prisonerId: String,
 
-  @NotBlank
+  @field:NotBlank
   @JsonProperty("prisonId")
   val prisonCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/VisitBookedInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/VisitBookedInfo.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.
 import jakarta.validation.constraints.NotBlank
 
 data class VisitBookedInfo(
-  @NotBlank
+  @field:NotBlank
   val reference: String,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/VisitCancelledInfo.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/additionalinfo/VisitCancelledInfo.kt
@@ -3,6 +3,6 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.
 import jakarta.validation.constraints.NotBlank
 
 data class VisitCancelledInfo(
-  @NotBlank
+  @field:NotBlank
   val reference: String,
 )


### PR DESCRIPTION
## What does this PR do?
Instead of failing the whole allocation job, handle the error and return null. The allocation service will see the list is null, and pull the prisoners level via an additional API call. This logic will only be used in the event the incentives API endpoint fails.