### PR TITLE
Add comment to better describe endpoint

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/controller/NomisController.kt
@@ -36,7 +36,7 @@ class NomisController(
   @PostMapping(VO_PRISONER_MIGRATION)
   @Operation(
     summary = "Endpoint to migrate prisoner VO / PVO balances from NOMIS to DPS.",
-    description = "Takes a prisoner and 'onboards' them onto DPS, syncing their balance with NOMIS.",
+    description = "Takes a prisoner and 'onboards' them onto DPS, syncing their balance with NOMIS. Also used by NOMIS for Initial IEP Entitlement syncs, not just initial migration",
     responses = [
       ApiResponse(
         responseCode = "200",


### PR DESCRIPTION
## What does this PR do?
This PR updates the description of the migrate endpoint to inform users that the endpoint is used for 2 purposes.

1. Initial migration for a new prisoner.
2. To re-setup a prisoners balance when an IEP Entitlement sync happens on NOMIS side. They needed to reset the balance and not use the sync endpoint, so this seemed like the best endpoint for that purpose.