### PR TITLE
Add slack channel release notification

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -92,5 +92,6 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2 # WORKFLOW_VERSION
     secrets: inherit
     with:
+      slack_notification: true
       environment: 'prod'
       app_version: '${{ needs.build.outputs.app_version }}'


### PR DESCRIPTION
## What does this PR do?
Sets the slack_notification flag to true for prod releases. It uses the ENV var set in GitHub -> Settings -> Variables, PROD_SLACK_RELEASE which we've set to visits-releases.