### PR TITLE
Bug - Fix transaction boundries causing locks to exit too early

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisMigrationService.kt
@@ -29,7 +29,7 @@ class NomisMigrationService(
   fun migratePrisoner(migrationDto: VisitAllocationPrisonerMigrationDto) {
     LOG.info("Entered NomisMigrationService - migratePrisoner with migration dto {}", migrationDto)
 
-    // If prisoner exists, reset their details and balance ready for migration
+    // If the prisoner exists, reset their details and balance ready for migration
     if (prisonerDetailsService.getPrisonerDetails(migrationDto.prisonerId) != null) {
       LOG.info("Prisoner ${migrationDto.prisonerId} found in DB, resetting their balance ready for migration")
       prisonerDetailsService.removePrisonerDetails(migrationDto.prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisService.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundExcepti
 class NomisService(
   private val nomisSyncService: NomisSyncService,
   private val nomisMigrationService: NomisMigrationService,
-  private val prisonerDetailsService: PrisonerDetailsService,
   private val changeLogService: ChangeLogService,
 ) {
   companion object {
@@ -21,11 +20,6 @@ class NomisService(
   }
 
   fun processSyncRequest(syncDto: VisitAllocationPrisonerSyncDto) {
-    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(syncDto.prisonerId)
-    if (dpsPrisoner == null) {
-      prisonerDetailsService.createPrisonerDetails(syncDto.prisonerId, syncDto.createdDate, null)
-    }
-
     nomisSyncService.syncPrisonerAdjustmentChanges(syncDto)
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/NomisSyncService.kt
@@ -38,7 +38,9 @@ class NomisSyncService(
 
     validateSyncRequest(syncDto)
 
-    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(syncDto.prisonerId)!!
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(syncDto.prisonerId)
+      ?: prisonerDetailsService.createPrisonerDetails(syncDto.prisonerId, syncDto.createdDate, null)
+
     compareBalanceBeforeSync(syncDto, dpsPrisoner.getBalance())
 
     LOG.info("Current loaded prisoner info - ${dpsPrisoner.prisonerId}, VOs ${dpsPrisoner.visitOrders.size}, NVOs ${dpsPrisoner.negativeVisitOrders.size}")
@@ -93,7 +95,8 @@ class NomisSyncService(
       }
     }
 
-    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)!!
+    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)
+      ?: prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
 
     val voBalanceChange = (prisonerNomisBalance.remainingVo - dpsPrisoner.getVoBalance())
     processSync(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -3,13 +3,11 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
 import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
 import java.time.LocalDate
 import kotlin.jvm.optionals.getOrNull
 
-@Transactional
 @Service
 class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDetailsRepository) {
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/SnsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/SnsService.kt
@@ -19,7 +19,7 @@ class SnsService(
   private val hmppsQueueService: HmppsQueueService,
   private val telemetryClient: TelemetryClient,
   private val objectMapper: ObjectMapper,
-  @Value("\${feature.events.sns.enabled:true}")
+  @param:Value("\${feature.events.sns.enabled:true}")
   private val snsEventsEnabled: Boolean,
   private val changeLogService: ChangeLogService,
 ) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerBookingMovedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerBookingMovedEventHandler.kt
@@ -6,10 +6,8 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerBookingMovedInfo
-import java.time.LocalDate
 
 @Service
 class PrisonerBookingMovedEventHandler(
@@ -17,7 +15,6 @@ class PrisonerBookingMovedEventHandler(
   private val prisonService: PrisonService,
   private val prisonerSearchClient: PrisonerSearchClient,
   private val nomisSyncService: NomisSyncService,
-  private val prisonerDetailsService: PrisonerDetailsService,
 ) : DomainEventHandler {
 
   override fun handle(domainEvent: DomainEvent) {
@@ -35,11 +32,6 @@ class PrisonerBookingMovedEventHandler(
   }
 
   private fun processNomis(prisonerId: String) {
-    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(prisonerId)
-    if (dpsPrisoner == null) {
-      prisonerDetailsService.createPrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
-    }
-
     nomisSyncService.syncPrisonerBalanceFromEventChange(prisonerId, DomainEventType.PRISONER_BOOKING_MOVED_EVENT_TYPE)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/PrisonerMergedEventHandler.kt
@@ -8,12 +8,10 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.NomisSyncService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.SnsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.PrisonerMergedInfo
-import java.time.LocalDate
 
 @Service
 class PrisonerMergedEventHandler(
@@ -24,7 +22,6 @@ class PrisonerMergedEventHandler(
   private val processPrisonerService: ProcessPrisonerService,
   private val snsService: SnsService,
   private val changeLogService: ChangeLogService,
-  private val prisonerDetailsService: PrisonerDetailsService,
 ) : DomainEventHandler {
 
   companion object {
@@ -53,11 +50,6 @@ class PrisonerMergedEventHandler(
 
   private fun processDps(info: PrisonerMergedInfo) {
     LOG.info("Handling DPS prison merge event - $info")
-    val newPrisonerDetails = prisonerDetailsService.getPrisonerDetails(info.prisonerId)
-    if (newPrisonerDetails == null) {
-      prisonerDetailsService.createPrisonerDetails(info.prisonerId, LocalDate.now().minusDays(14), null)
-    }
-
     val changeLogReference = processPrisonerService.processPrisonerMerge(info.prisonerId, info.removedPrisonerId)
     if (changeLogReference != null) {
       val changeLog = changeLogService.findChangeLogForPrisonerByReference(info.prisonerId, changeLogReference)
@@ -70,11 +62,6 @@ class PrisonerMergedEventHandler(
   }
 
   private fun processNomis(info: PrisonerMergedInfo) {
-    val dpsPrisoner = prisonerDetailsService.getPrisonerDetails(info.prisonerId)
-    if (dpsPrisoner == null) {
-      prisonerDetailsService.createPrisonerDetails(info.prisonerId, LocalDate.now().minusDays(14), null)
-    }
-
     nomisSyncService.syncPrisonerBalanceFromEventChange(info.prisonerId, DomainEventType.PRISONER_MERGED_EVENT_TYPE)
     nomisSyncService.syncPrisonerRemoved(info.removedPrisonerId)
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -8,12 +8,10 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.VisitSchedulerClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.SnsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.VisitBookedInfo
-import java.time.LocalDate
 
 @Service
 class VisitBookedEventHandler(
@@ -24,7 +22,6 @@ class VisitBookedEventHandler(
   private val processPrisonerService: ProcessPrisonerService,
   private val snsService: SnsService,
   private val changeLogService: ChangeLogService,
-  private val prisonerDetailsService: PrisonerDetailsService,
 ) : DomainEventHandler {
 
   companion object {
@@ -41,13 +38,9 @@ class VisitBookedEventHandler(
 
     if (prisonService.getPrisonEnabledForDpsByCode(visit.prisonCode)) {
       LOG.info("Prison ${visit.prisonCode} is enabled for DPS, processing event")
+
       val prisoner = prisonerSearchClient.getPrisonerById(visit.prisonerId)
       if (prisoner.convictedStatus == CONVICTED) {
-        val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)
-        if (dpsPrisonerDetails == null) {
-          prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
-        }
-
         val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit)
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
@@ -12,7 +12,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerSe
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.SnsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.DomainEvent
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.events.additionalinfo.VisitCancelledInfo
-import java.time.LocalDate
 
 @Service
 class VisitCancelledEventHandler(
@@ -38,12 +37,9 @@ class VisitCancelledEventHandler(
 
     if (prisonService.getPrisonEnabledForDpsByCode(visit.prisonCode)) {
       LOG.info("Prison ${visit.prisonCode} is enabled for DPS, processing event")
-      val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetails(visit.prisonerId)
-      if (dpsPrisonerDetails == null) {
-        prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
-      }
 
       val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit)
+
       val changeLog = changeLogService.findChangeLogForPrisonerByReference(visit.prisonerId, changeLogReference)
       if (changeLog != null) {
         snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)


### PR DESCRIPTION
## What does this PR do?
As the top level service was outside of a transaction, the call to get or create the new prisoner details, opened a transaction but instantly closed after exiting the sub service. Leaving the top level service to make the next call without a lock.

## Original Issue
Issue spotted: This meant 2 transactions were racing to complete, and the 2nd transaction found "orphaned" records from the 1st, and deleted them on transaction closure.

## Fix
Fix: The transaction boundry should get or create the prisoner, and now keep the lock open and make all changes / inserts before releasing.