### PR TITLE
Bug - Issue with Hibernate, JPA, data classes and orphanRemoval = true

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/snapshots/VOSnap.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/snapshots/VOSnap.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots
+
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.NegativeVisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// NOTICE: Used to track changes made during allocation / sync, to determine if a change_log entry should be generated.
+
+data class VOSnap(
+  val id: Long?,
+  val type: VisitOrderType,
+  val status: VisitOrderStatus,
+  val created: LocalDateTime,
+  val expiry: LocalDate?,
+  val visitRef: String?,
+)
+
+data class NVOSnap(
+  val id: Long?,
+  val type: VisitOrderType,
+  val status: NegativeVisitOrderStatus,
+  val created: LocalDateTime,
+  val repaid: LocalDate?,
+)
+
+data class PrisonerSnap(
+  val prisonerId: String,
+  val lastVoAllocationDate: LocalDate,
+  val lastPvoAllocationDate: LocalDate?,
+  val vos: List<VOSnap>,
+  val nvos: List<NVOSnap>,
+)
+
+// Extension mappers (call these inside a transaction so LAZY loads are fine)
+fun VisitOrder.toSnap() = VOSnap(id, type, status, createdTimestamp, expiryDate, visitReference)
+
+fun NegativeVisitOrder.toSnap() = NVOSnap(id, type, status, createdTimestamp, repaidDate)
+
+fun PrisonerDetails.snapshot() = PrisonerSnap(
+  prisonerId,
+  lastVoAllocatedDate,
+  lastPvoAllocatedDate,
+  visitOrders.map { it.toSnap() },
+  negativeVisitOrders.map { it.toSnap() },
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import java.time.LocalDateTime
@@ -54,4 +55,13 @@ data class ChangeLog(
 
   @Column(nullable = false)
   val reference: UUID,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as ChangeLog
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/ChangeLog.kt
@@ -18,7 +18,7 @@ import java.util.UUID
 
 @Entity
 @Table(name = "change_log")
-data class ChangeLog(
+open class ChangeLog(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "negative_visit_order")
-data class NegativeVisitOrder(
+open class NegativeVisitOrder(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/NegativeVisitOrder.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import java.time.LocalDate
@@ -45,4 +46,13 @@ data class NegativeVisitOrder(
   @ManyToOne
   @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
   val prisoner: PrisonerDetails,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as NegativeVisitOrder
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
@@ -10,6 +10,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import java.time.LocalDate
@@ -45,4 +46,13 @@ data class VisitOrder(
   @ManyToOne
   @JoinColumn(name = "prisoner_id", referencedColumnName = "prisonerId", insertable = false, updatable = false)
   val prisoner: PrisonerDetails,
-)
+) {
+  override fun equals(other: Any?): Boolean {
+    if (this === other) return true
+    if (other == null || Hibernate.getClass(this) != Hibernate.getClass(other)) return false
+    other as VisitOrder
+    return id == other.id
+  }
+
+  override fun hashCode(): Int = javaClass.hashCode()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrder.kt
@@ -18,7 +18,7 @@ import java.time.LocalDateTime
 
 @Entity
 @Table(name = "visit_order")
-data class VisitOrder(
+open class VisitOrder(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0L,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/utils/PrisonerChangeTrackingUtil.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/utils/PrisonerChangeTrackingUtil.kt
@@ -1,0 +1,42 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.utils
+
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.NVOSnap
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.PrisonerSnap
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.VOSnap
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.snapshot
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+
+class PrisonerChangeTrackingUtil {
+  companion object {
+
+    fun hasChangeOccurred(before: PrisonerSnap, afterEntity: PrisonerDetails): Boolean {
+      val after = afterEntity.snapshot()
+      if (before.prisonerId != after.prisonerId) return true
+      if (before.lastVoAllocationDate != after.lastVoAllocationDate) return true
+      if (before.lastPvoAllocationDate != after.lastPvoAllocationDate) return true
+      return changedVos(before.vos, after.vos) || changedNvos(before.nvos, after.nvos)
+    }
+
+    private fun changedVos(before: List<VOSnap>, after: List<VOSnap>): Boolean {
+      fun key(v: VOSnap) = v.id ?: (v.type to v.created)
+      if (before.size != after.size) return true
+      val afterMap = after.associateBy(::key)
+      for (b in before) {
+        val a = afterMap[key(b)] ?: return true
+        if (a.status != b.status || a.expiry != b.expiry || a.visitRef != b.visitRef) return true
+      }
+      return false
+    }
+
+    private fun changedNvos(before: List<NVOSnap>, after: List<NVOSnap>): Boolean {
+      fun key(n: NVOSnap) = n.id ?: (n.type to n.created)
+      if (before.size != after.size) return true
+      val afterMap = after.associateBy(::key)
+      for (b in before) {
+        val a = afterMap[key(b)] ?: return true
+        if (a.status != b.status || a.repaid != b.repaid) return true
+      }
+      return false
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

We believe a data issue is happening where requests are removing previous requests saved child objects due to issues with using data classes and their default equals / hashcode methods in kotlin. Hibernate seems to be marking the old objects are orphans and cleaning them up incorrectly.

Fix: Add overrides for each of the equals / hashcode methods. Also remove the use of deepCopy as this could cause issues in the future if a dev accidentally called to save this copied object.