### PR TITLE
Add version locking to parent entity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType
 import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import jakarta.persistence.Version
 import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.PrisonerBalanceDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
@@ -16,7 +17,7 @@ import java.time.LocalDate
 
 @Entity
 @Table(name = "prisoner_details")
-open class PrisonerDetails(
+class PrisonerDetails(
   @Id
   @Column(nullable = false)
   val prisonerId: String,
@@ -35,6 +36,10 @@ open class PrisonerDetails(
 
   @OneToMany(mappedBy = "prisoner", fetch = FetchType.LAZY, cascade = [CascadeType.PERSIST, CascadeType.MERGE], orphanRemoval = true)
   val changeLogs: MutableList<ChangeLog> = mutableListOf()
+
+  @Version
+  @Column(nullable = false)
+  var rowVersion: Long = 0L
 
   fun getBalance(): PrisonerBalanceDto = PrisonerBalanceDto(
     prisonerId = prisonerId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -4,10 +4,12 @@ import jakarta.persistence.LockModeType
 import jakarta.persistence.QueryHint
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.jpa.repository.QueryHints
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import java.time.LocalDate
 import java.util.*
 
 @Repository
@@ -17,4 +19,8 @@ interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String> {
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")])
   @Query("SELECT pd FROM PrisonerDetails pd WHERE pd.prisonerId = :id")
   fun findByIdWithLock(id: String): Optional<PrisonerDetails>
+
+  @Modifying
+  @Query("INSERT INTO PrisonerDetails (prisonerId, lastVoAllocatedDate, lastPvoAllocatedDate) VALUES (:prisonerId, :lastVoAllocatedVoDate, :lastPvoAllocatedVoDate)")
+  fun insertNewPrisonerDetails(prisonerId: String, lastVoAllocatedVoDate: LocalDate, lastPvoAllocatedVoDate: LocalDate?)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/PrisonerDetailsRepository.kt
@@ -13,7 +13,7 @@ import java.util.*
 @Repository
 interface PrisonerDetailsRepository : JpaRepository<PrisonerDetails, String> {
 
-  @Lock(LockModeType.PESSIMISTIC_WRITE)
+  @Lock(LockModeType.OPTIMISTIC_FORCE_INCREMENT)
   @QueryHints(value = [QueryHint(name = "jakarta.persistence.lock.timeout", value = "5000")])
   @Query("SELECT pd FROM PrisonerDetails pd WHERE pd.prisonerId = :id")
   fun findByIdWithLock(id: String): Optional<PrisonerDetails>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -16,13 +16,15 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId, newLastAllocatedDate - $newLastAllocatedDate and newLastPvoAllocatedDate - $newLastPvoAllocatedDate")
-    return prisonerDetailsRepository.save(
+    val insertedPrisoner = prisonerDetailsRepository.saveAndFlush(
       PrisonerDetails(
         prisonerId = prisonerId,
         lastVoAllocatedDate = newLastAllocatedDate,
         lastPvoAllocatedDate = newLastPvoAllocatedDate,
       ),
     )
+
+    return prisonerDetailsRepository.findByIdWithLock(insertedPrisoner.prisonerId).get()
   }
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -16,13 +16,9 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId, newLastAllocatedDate - $newLastAllocatedDate and newLastPvoAllocatedDate - $newLastPvoAllocatedDate")
-    return prisonerDetailsRepository.save(
-      PrisonerDetails(
-        prisonerId = prisonerId,
-        lastVoAllocatedDate = newLastAllocatedDate,
-        lastPvoAllocatedDate = newLastPvoAllocatedDate,
-      ),
-    )
+    prisonerDetailsRepository.insertNewPrisonerDetails(prisonerId = prisonerId, lastVoAllocatedVoDate = newLastAllocatedDate, lastPvoAllocatedVoDate = null)
+
+    return prisonerDetailsRepository.findByIdWithLock(prisonerId).get()
   }
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerDetailsService.kt
@@ -16,15 +16,13 @@ class PrisonerDetailsService(private val prisonerDetailsRepository: PrisonerDeta
 
   fun createPrisonerDetails(prisonerId: String, newLastAllocatedDate: LocalDate, newLastPvoAllocatedDate: LocalDate?): PrisonerDetails {
     LOG.info("PrisonerDetailsService - createPrisonerDetails called with prisonerId - $prisonerId, newLastAllocatedDate - $newLastAllocatedDate and newLastPvoAllocatedDate - $newLastPvoAllocatedDate")
-    val insertedPrisoner = prisonerDetailsRepository.saveAndFlush(
+    return prisonerDetailsRepository.save(
       PrisonerDetails(
         prisonerId = prisonerId,
         lastVoAllocatedDate = newLastAllocatedDate,
         lastPvoAllocatedDate = newLastPvoAllocatedDate,
       ),
     )
-
-    return prisonerDetailsRepository.findByIdWithLock(insertedPrisoner.prisonerId).get()
   }
 
   fun getPrisonerDetails(prisonerId: String): PrisonerDetails? {

--- a/src/main/resources/db/migration/V1_18__alter_prisoner_details_table_add_row_locking_version.sql
+++ b/src/main/resources/db/migration/V1_18__alter_prisoner_details_table_add_row_locking_version.sql
@@ -1,0 +1,1 @@
+ALTER TABLE prisoner_details ADD COLUMN row_version BIGINT NOT NULL DEFAULT 0;


### PR DESCRIPTION
## What does this PR do?
On insert or get at transaction open, a version lock with forced increment will be held. On completion of the transaction, the lock will update the version by +1 and if the version isn't past the current int held in the DB we will bounce it back with an exception.