### PR TITLE
Bug - Fix: Enforce VO cap during VO refund process

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
@@ -38,9 +38,11 @@ class VisitCancelledEventHandler(
 
       val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit)
 
-      val changeLog = changeLogService.findChangeLogForPrisonerByReference(visit.prisonerId, changeLogReference)
-      if (changeLog != null) {
-        snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
+      if (changeLogReference != null) {
+        val changeLog = changeLogService.findChangeLogForPrisonerByReference(visit.prisonerId, changeLogReference)
+        if (changeLog != null) {
+          snsService.sendPrisonAllocationAdjustmentCreatedEvent(changeLog)
+        }
       }
     } else {
       LOG.info("Prison ${visit.prisonCode} is not enabled for DPS, skipping processing")


### PR DESCRIPTION
If prisoner is at the maximum 26 VOs and a refund event comes in (visit cancelled) then skip refunding.