### PR TITLE
Reduce auth calls via caching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/ClientCachingOAuth2AuthorizedClientService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/ClientCachingOAuth2AuthorizedClientService.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.config
+
+import org.springframework.security.core.Authentication
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientId
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import java.util.concurrent.ConcurrentHashMap
+
+class ClientCachingOAuth2AuthorizedClientService(
+  private val clientRegistrationRepository: ClientRegistrationRepository,
+) : OAuth2AuthorizedClientService {
+  private val authorizedClients: MutableMap<OAuth2AuthorizedClientId, OAuth2AuthorizedClient> = ConcurrentHashMap()
+
+  override fun <T : OAuth2AuthorizedClient?> loadAuthorizedClient(
+    clientRegistrationId: String,
+    principalName: String,
+  ): T? = clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.let {
+    @Suppress("UNCHECKED_CAST")
+    authorizedClients[OAuth2AuthorizedClientId(clientRegistrationId, "HMPPS_VISIT_ALLOCATION_API")] as T
+  }
+
+  override fun saveAuthorizedClient(authorizedClient: OAuth2AuthorizedClient, principal: Authentication) {
+    authorizedClients[
+      OAuth2AuthorizedClientId(authorizedClient.clientRegistration.registrationId, "HMPPS_VISIT_ALLOCATION_API"),
+    ] = authorizedClient
+  }
+
+  override fun removeAuthorizedClient(clientRegistrationId: String, principalName: String) {
+    clientRegistrationRepository.findByRegistrationId(clientRegistrationId)?.apply {
+      authorizedClients.remove(OAuth2AuthorizedClientId(clientRegistrationId, "HMPPS_VISIT_ALLOCATION_API"))
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/OAuth2ClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/config/OAuth2ClientConfiguration.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.oauth2.client.AuthorizedClientServiceOAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+
+@Configuration
+class OAuth2ClientConfiguration {
+
+  @Bean
+  fun authorizedClientManager(
+    clientRegistrationRepository: ClientRegistrationRepository,
+  ): OAuth2AuthorizedClientManager {
+    val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder().clientCredentials().build()
+    val authorizedClientManager =
+      AuthorizedClientServiceOAuth2AuthorizedClientManager(
+        clientRegistrationRepository,
+        ClientCachingOAuth2AuthorizedClientService(clientRegistrationRepository),
+      )
+    authorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+    return authorizedClientManager
+  }
+}


### PR DESCRIPTION
## What does this PR do?
Uses caching to reduce excess hmpps auth calls. Code provided via hmpps-dev team.