### PR TITLE
VB-5917 - Limit max concurrent message processing per pod to 2

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -26,7 +26,7 @@ class DomainEventListener(
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2")
   fun processMessage(sqsMessage: SQSMessage): CompletableFuture<Void?> {
     if (domainEventProcessingEnabled) {
       val event = objectMapper.readValue(sqsMessage.message, DomainEvent::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationByPrisonJobListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationByPrisonJobListener.kt
@@ -18,7 +18,7 @@ class VisitAllocationByPrisonJobListener(
     const val PRISON_VISITS_ALLOCATION_EVENT_JOB_QUEUE_CONFIG_KEY = "visitsallocationeventjob"
   }
 
-  @SqsListener(PRISON_VISITS_ALLOCATION_EVENT_JOB_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(PRISON_VISITS_ALLOCATION_EVENT_JOB_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2")
   fun processMessage(visitAllocationEventJob: VisitAllocationEventJob): CompletableFuture<Void?> = CoroutineScope(Context.current().asContextElement()).future {
     visitAllocationByPrisonJobListenerService.handleVisitAllocationJob(visitAllocationEventJob)
     null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
@@ -20,7 +20,7 @@ class VisitAllocationPrisonerRetryQueueListener(private val prisonerRetryService
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy")
+  @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2")
   fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.current().asContextElement()).future {
     log.debug("Processing prisoner on the visits allocation prisoner retry queue - {}", visitAllocationPrisonerRetryJob)
     prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.jobReference, visitAllocationPrisonerRetryJob.prisonerId)


### PR DESCRIPTION
## What does this PR do?
Each pod uses 2 CPUs. We believe lowering the max concurrent messages from the default 10 to 2, makes sense and should help avoid stressing the pods and DB connection pools.