### PR TITLE
VB-5977 - Handle failure for prisons with large convicted prison capacity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.clients
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -14,6 +15,7 @@ import java.util.concurrent.TimeoutException
 @Component
 class PrisonerSearchClient(
   @Qualifier("prisonerSearchWebClient") private val webClient: WebClient,
+  @Value("\${prisoner-search.attribute-search.page-size:500}") private val attributeSearchPageSize: Int,
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
@@ -45,7 +47,7 @@ class PrisonerSearchClient(
 
     return webClient
       .post()
-      .uri("/attribute-search?size=100")
+      .uri("/attribute-search?size=$attributeSearchPageSize")
       .bodyValue(requestBody)
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
@@ -45,7 +45,7 @@ class PrisonerSearchClient(
 
     return webClient
       .post()
-      .uri("/attribute-search?size=10000")
+      .uri("/attribute-search?size=100")
       .bodyValue(requestBody)
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.clients.RestPage
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
 
@@ -64,7 +65,7 @@ class AllocationService(
 
   private fun getConvictedPrisonersForPrison(jobReference: String, prisonId: String): List<PrisonerDto> {
     val convictedPrisonersForPrison = try {
-      prisonerSearchClient.getConvictedPrisonersByPrisonId(prisonId).content.toList()
+      getAllPrisoners(prisonerSearchClient.getConvictedPrisonersByPrisonId(prisonId))
     } catch (e: Exception) {
       val failureMessage = "failed to get convicted prisoners by prisonId - $prisonId"
       LOG.error(failureMessage, e)
@@ -86,5 +87,15 @@ class AllocationService(
     }
 
     return incentiveLevelsForPrison
+  }
+
+  private fun getAllPrisoners(restPage: RestPage<PrisonerDto>): List<PrisonerDto> {
+    val prisoners = mutableListOf<PrisonerDto>()
+    prisoners.addAll(restPage.content)
+    while (restPage.hasNext()) {
+      prisoners.addAll(restPage.content)
+    }
+
+    return prisoners.toList()
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,3 +95,7 @@ feature:
   events:
     sns:
       enabled: true
+
+prisoner-search:
+  attribute-search:
+    page-size: 500

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.springframework.http.HttpStatus
-import org.springframework.test.context.TestPropertySource
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
@@ -32,7 +31,6 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
-@TestPropertySource(properties = ["prisoner-search.attribute-search.page-size=100"])
 class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
   companion object {
     const val PRISON_CODE = "MDI"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -857,10 +857,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
   }
 
   /**
-   * Scenario - Allocation: Visit allocation job is run, and all prisoners are allocated visit orders (VO / PVO).
-   * Prisoner1 - Standard incentive, Gets 1 VO, 0 PVO.
-   * Prisoner2 - Enhanced incentive, Gets 2 VO, 1 PVO.
-   * Prisoner3 - Enhanced2 incentive, Gets 3 VO, 2 PVOs.
+   * Scenario - 205 prisoners, all with Standard (STD) incentive.
    */
   @Test
   fun `when visit allocation job run for a prison and number of prisoners are more than page capacity of 100 then processMessage is called and visit orders are created for convicted prisoners`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.springframework.http.HttpStatus
+import org.springframework.test.context.TestPropertySource
 import software.amazon.awssdk.services.sqs.model.SendMessageRequest
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
@@ -31,6 +32,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.concurrent.TimeUnit
 
+@TestPropertySource(properties = ["prisoner-search.attribute-search.page-size=100"])
 class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
   companion object {
     const val PRISON_CODE = "MDI"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -856,6 +856,59 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.count { it.prisoner.prisonerId == prisonerId && it.type == type && it.status == status }).isEqualTo(total)
   }
 
+  /**
+   * Scenario - Allocation: Visit allocation job is run, and all prisoners are allocated visit orders (VO / PVO).
+   * Prisoner1 - Standard incentive, Gets 1 VO, 0 PVO.
+   * Prisoner2 - Enhanced incentive, Gets 2 VO, 1 PVO.
+   * Prisoner3 - Enhanced2 incentive, Gets 3 VO, 2 PVOs.
+   */
+  @Test
+  fun `when visit allocation job run for a prison and number of prisoners are more than page capacity of 100 then processMessage is called and visit orders are created for convicted prisoners`() {
+    // Given - message sent to start allocation job for prison
+    val sendMessageRequestBuilder = SendMessageRequest.builder().queueUrl(prisonVisitsAllocationEventJobQueueUrl)
+    val allocationJobReference = "job-ref"
+    val event = VisitAllocationEventJob(allocationJobReference, PRISON_CODE)
+    val message = objectMapper.writeValueAsString(event)
+    val sendMessageRequest = sendMessageRequestBuilder.messageBody(message).build()
+    visitOrderAllocationPrisonJobRepository.save(VisitOrderAllocationPrisonJob(allocationJobReference = allocationJobReference, prisonCode = PRISON_CODE))
+    val convictedPrisoners = mutableListOf<PrisonerDto>()
+
+    // When
+    // there are 205 convicted prisoners with STD incentive - while page limit on prisoner search is 100
+    for (i in 1..205) {
+      val prisoner = PrisonerDto(prisonerId = "ABC$i", prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = "HEI")
+      convictedPrisoners.add(prisoner)
+      prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisoner.prisonerId, createPrisonerDto(prisonerId = prisoner.prisonerId, prisonId = PRISON_CODE, inOutStatus = "IN", lastPrisonId = PRISON_CODE))
+      incentivesMockServer.stubGetPrisonerIncentiveReviewHistory(prisoner.prisonerId, prisonerIncentivesDto = PrisonerIncentivesDto("STD"))
+    }
+
+    prisonerSearchMockServer.stubGetConvictedPrisoners(PRISON_CODE, convictedPrisoners)
+
+    incentivesMockServer.stubGetAllPrisonIncentiveLevels(
+      prisonId = PRISON_CODE,
+      listOf(
+        PrisonIncentiveAmountsDto(visitOrders = 1, privilegedVisitOrders = 0, levelCode = "STD"),
+      ),
+    )
+
+    prisonVisitsAllocationEventJobSqsClient.sendMessage(sendMessageRequest)
+
+    await untilCallTo { prisonVisitsAllocationEventJobSqsClient.countMessagesOnQueue(prisonVisitsAllocationEventJobQueueUrl).get() } matches { it == 0 }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(visitAllocationByPrisonJobListenerSpy, times(1)).processMessage(event) }
+    await untilAsserted { verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any()) }
+
+    val visitOrders = visitOrderRepository.findAll()
+
+    assertThat(visitOrders.size).isEqualTo(205)
+
+    verify(visitOrderAllocationPrisonJobRepository, times(1)).updateStartTimestamp(any(), any(), any())
+    verify(visitOrderAllocationPrisonJobRepository, times(1)).updateEndTimestampAndStats(any(), any(), any(), any(), any(), any())
+    verify(snsService, times(205)).sendPrisonAllocationAdjustmentCreatedEvent(any())
+    val visitOrderAllocationPrisonJobs = visitOrderAllocationPrisonJobRepository.findAll()
+    assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 205, processedPrisoners = 205, failedOrSkippedPrisoners = 0)
+  }
+
   private fun assertVisitOrderAllocationPrisonJob(
     visitOrderAllocationPrisonJob: VisitOrderAllocationPrisonJob,
     failureMessage: String?,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -38,7 +38,7 @@ class PrisonerSearchMockServer : WireMockServer(8094) {
   ) {
     val responseBuilder = createJsonResponseBuilder()
     stubFor(
-      post("/attribute-search?size=500")
+      post("/attribute-search?size=100")
         .willReturn(
           if (convictedPrisoners == null) {
             responseBuilder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -38,7 +38,7 @@ class PrisonerSearchMockServer : WireMockServer(8094) {
   ) {
     val responseBuilder = createJsonResponseBuilder()
     stubFor(
-      post("/attribute-search?size=10000")
+      post("/attribute-search?size=100")
         .willReturn(
           if (convictedPrisoners == null) {
             responseBuilder

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -38,7 +38,7 @@ class PrisonerSearchMockServer : WireMockServer(8094) {
   ) {
     val responseBuilder = createJsonResponseBuilder()
     stubFor(
-      post("/attribute-search?size=100")
+      post("/attribute-search?size=500")
         .willReturn(
           if (convictedPrisoners == null) {
             responseBuilder

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,3 +63,7 @@ feature:
   events:
     sns:
       enabled: true
+
+prisoner-search:
+  attribute-search:
+    page-size: 100


### PR DESCRIPTION
Reduce page size on prisoner search /attribute-search to 100 from 10000 as it seems to fail when a big number of results are returned for prisons with a big capacity.