### PR TITLE
VB-5978 - Handle special prison codes on allocation api

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -16,6 +16,7 @@ generic-service:
     VISIT-SCHEDULER_API_URL: "https://visit-scheduler-dev.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
     FEATURE_EVENTS_SNS_ENABLED: true
+    FEATURE_DPS_PROCESS_SPECIAL_PRISON_CODES_ENABLED: false
 
   scheduledDowntime:
     enabled: true

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -16,6 +16,7 @@ generic-service:
     VISIT-SCHEDULER_API_URL: "https://visit-scheduler-preprod.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
     FEATURE_EVENTS_SNS_ENABLED: true
+    FEATURE_DPS_PROCESS_SPECIAL_PRISON_CODES_ENABLED: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -27,6 +27,7 @@ generic-service:
     VISIT-SCHEDULER_API_URL: "https://visit-scheduler.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
     FEATURE_EVENTS_SNS_ENABLED: true
+    FEATURE_DPS_PROCESS_SPECIAL_PRISON_CODES_ENABLED: false
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -16,6 +16,7 @@ generic-service:
     VISIT-SCHEDULER_API_URL: "https://visit-scheduler-staging.prison.service.justice.gov.uk"
     SQS_DOMAIN_EVENT_PROCESSING_ENABLED: true
     FEATURE_EVENTS_SNS_ENABLED: false # A lot of DPS services don't have staging. Disabling.
+    FEATURE_DPS_PROCESS_SPECIAL_PRISON_CODES_ENABLED: false
 
   scheduledDowntime:
     enabled: true

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/SpecialPrisonCodes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/SpecialPrisonCodes.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.enums
+
+@Suppress("unused")
+enum class SpecialPrisonCodes {
+  OUT,
+  TRN,
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,3 +95,5 @@ feature:
   events:
     sns:
       enabled: true
+  dps-process-special-prison-codes:
+    enabled: ${FEATURE_DPS_PROCESS_SPECIAL_PRISON_CODES_ENABLED}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -63,3 +63,5 @@ feature:
   events:
     sns:
       enabled: true
+  dps-process-special-prison-codes:
+    enabled: false


### PR DESCRIPTION
## What does this PR do?
some prison codes do not belong directly to a prison, such as TRN or OUT. Add logic to correctly handle these codes. If all prisons are enabled for DPS then enable the feature, and DPS will automatically start owning these codes too.