### PR TITLE
Use custom requestFields parameter to avoid overfetching

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/PrisonerSearchClient.kt
@@ -7,6 +7,7 @@ import org.springframework.http.MediaType
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.AttributeSearchPrisonerDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ConvictedStatus
 import java.util.concurrent.TimeoutException
@@ -17,6 +18,9 @@ class PrisonerSearchClient(
 ) {
   companion object {
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
+
+    const val DEFAULT_PAGE_SIZE = 5000
+    const val RESPONSE_FIELD = "prisonerNumber"
   }
 
   fun getPrisonerById(prisonerId: String): PrisonerDto {
@@ -29,7 +33,7 @@ class PrisonerSearchClient(
       .block() ?: throw TimeoutException("Request timed out while fetching prisoner with ID $prisonerId")
   }
 
-  fun getConvictedPrisonersByPrisonId(prisonId: String): RestPage<PrisonerDto> {
+  fun getConvictedPrisonersByPrisonId(prisonId: String): RestPage<AttributeSearchPrisonerDto> {
     LOG.info("Calling prisoner-search to get all convicted prisoners for prison $prisonId")
     val requestBody = AttributeSearch(
       queries = listOf(
@@ -45,11 +49,11 @@ class PrisonerSearchClient(
 
     return webClient
       .post()
-      .uri("/attribute-search?size=10000")
+      .uri("/attribute-search?size=$DEFAULT_PAGE_SIZE&responseFields=$RESPONSE_FIELD")
       .bodyValue(requestBody)
       .accept(MediaType.APPLICATION_JSON)
       .retrieve()
-      .bodyToMono<RestPage<PrisonerDto>>()
+      .bodyToMono<RestPage<AttributeSearchPrisonerDto>>()
       .block() ?: throw TimeoutException("Request timed out while fetching all prisoners from prison $prisonId")
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prisoner/search/AttributeSearchPrisonerDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/prisoner/search/AttributeSearchPrisonerDto.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search
+
+import com.fasterxml.jackson.annotation.JsonAlias
+import io.swagger.v3.oas.annotations.media.Schema
+
+data class AttributeSearchPrisonerDto(
+  @Schema(required = true, description = "Prisoner Number", example = "A1234AA")
+  @JsonAlias("prisonerNumber")
+  val prisonerId: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -7,7 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
-import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.AttributeSearchPrisonerDto
 
 @Transactional
 @Service
@@ -62,7 +62,7 @@ class AllocationService(
     LOG.info("Finished AllocationService - processPrisonAllocation with prisonCode: $prisonId, total records processed : ${allPrisoners.size}")
   }
 
-  private fun getConvictedPrisonersForPrison(jobReference: String, prisonId: String): List<PrisonerDto> {
+  private fun getConvictedPrisonersForPrison(jobReference: String, prisonId: String): List<AttributeSearchPrisonerDto> {
     val convictedPrisonersForPrison = try {
       prisonerSearchClient.getConvictedPrisonersByPrisonId(prisonId).content.toList()
     } catch (e: Exception) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/PrisonerSearchMockServer.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock
 
 import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock.containing
 import com.github.tomakehurst.wiremock.client.WireMock.get
 import com.github.tomakehurst.wiremock.client.WireMock.post
+import com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 import org.junit.jupiter.api.extension.AfterAllCallback
 import org.junit.jupiter.api.extension.BeforeAllCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
@@ -38,7 +40,9 @@ class PrisonerSearchMockServer : WireMockServer(8094) {
   ) {
     val responseBuilder = createJsonResponseBuilder()
     stubFor(
-      post("/attribute-search?size=10000")
+      post(urlPathEqualTo("/attribute-search"))
+        .withQueryParam("size", containing("5000"))
+        .withQueryParam("responseFields", containing("prisonerNumber"))
         .willReturn(
           if (convictedPrisoners == null) {
             responseBuilder


### PR DESCRIPTION
## What does this PR do?
Paging provides unstable results, to get around this we use the query parameter requestFields and pass in the single field we want back (their prisoner number). This avoids web client memory buffer exceptions and avoids the unstable results from paging