### PR TITLE
Attempt to split each jobs telemetry into their own spans

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.CoroutineScope
@@ -26,17 +28,35 @@ class DomainEventListener(
     private val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  private val tracer = GlobalOpenTelemetry.getTracer("uk.gov.justice.digital.hmpps.visitallocationapi.service.listener")
+
   @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
   fun processMessage(sqsMessage: SQSMessage): CompletableFuture<Void?> {
-    if (domainEventProcessingEnabled) {
-      val event = objectMapper.readValue(sqsMessage.message, DomainEvent::class.java)
-      return CoroutineScope(Context.current().asContextElement()).future {
-        domainEventListenerService.handleMessage(event)
-        null
+
+    val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
+      .setSpanKind(SpanKind.CONSUMER)
+      .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id
+      .startSpan()
+
+    val scope = span.makeCurrent()
+
+    try {
+      if (domainEventProcessingEnabled) {
+        val event = objectMapper.readValue(sqsMessage.message, DomainEvent::class.java)
+        return CoroutineScope(Context.root().asContextElement()).future {
+          domainEventListenerService.handleMessage(event)
+          null
+        }
+      } else {
+        LOG.debug("Domain event processing is disabled")
+        return CompletableFuture.completedFuture(null)
       }
-    } else {
-      LOG.debug("Domain event processing is disabled")
-      return CompletableFuture.completedFuture(null)
+    } catch (t: Throwable) {
+      span.recordException(t)
+      throw t
+    } finally {
+      scope.close()
+      span.end()
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -32,7 +32,6 @@ class DomainEventListener(
 
   @SqsListener(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
   fun processMessage(sqsMessage: SQSMessage): CompletableFuture<Void?> {
-
     val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
       .setSpanKind(SpanKind.CONSUMER)
       .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationByPrisonJobListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationByPrisonJobListener.kt
@@ -24,7 +24,7 @@ class VisitAllocationByPrisonJobListener(
 
   @SqsListener(PRISON_VISITS_ALLOCATION_EVENT_JOB_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
   fun processMessage(visitAllocationEventJob: VisitAllocationEventJob): CompletableFuture<Void?> = CoroutineScope(Context.root().asContextElement()).future {
-    val span = tracer.spanBuilder("VisitAllocationJob")
+    val span = tracer.spanBuilder("VisitAllocationPrisonAllocationJob")
       .setSpanKind(SpanKind.CONSUMER)
       .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id
       .startSpan()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
@@ -26,7 +26,6 @@ class VisitAllocationPrisonerRetryQueueListener(private val prisonerRetryService
 
   @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
   fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.root().asContextElement()).future {
-
     val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
       .setSpanKind(SpanKind.CONSUMER)
       .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.service.listener
 
 import io.awspring.cloud.sqs.annotation.SqsListener
+import io.opentelemetry.api.GlobalOpenTelemetry
+import io.opentelemetry.api.trace.SpanKind
 import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.CoroutineScope
@@ -20,10 +22,29 @@ class VisitAllocationPrisonerRetryQueueListener(private val prisonerRetryService
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  private val tracer = GlobalOpenTelemetry.getTracer("uk.gov.justice.digital.hmpps.visitallocationapi.service.listener")
+
   @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
-  fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.current().asContextElement()).future {
-    log.debug("Processing prisoner on the visits allocation prisoner retry queue - {}", visitAllocationPrisonerRetryJob)
-    prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.jobReference, visitAllocationPrisonerRetryJob.prisonerId)
+  fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.root().asContextElement()).future {
+
+    val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
+      .setSpanKind(SpanKind.CONSUMER)
+      .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id
+      .startSpan()
+
+    val scope = span.makeCurrent()
+
+    try {
+      log.debug("Processing prisoner on the visits allocation prisoner retry queue - {}", visitAllocationPrisonerRetryJob)
+      prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.jobReference, visitAllocationPrisonerRetryJob.prisonerId)
+    } catch (t: Throwable) {
+      span.recordException(t)
+      throw t
+    } finally {
+      scope.close()
+      span.end()
+    }
+
     null
   }
 }


### PR DESCRIPTION
## What does this PR do?
Currently all jobs from this queue process as 1 span, and are given the same operation_id, making it impossible to search the logs.

This PR aims to split each job to have it's own span, making logging much cleaner on Azure.