### PR TITLE
Fix potential memory growth issue

### DIFF
--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -28,7 +28,7 @@ generic-service:
 
   # Environment variables to load into the deployment
   env:
-    JAVA_OPTS: "-Xmx512m"
+    JAVA_OPTS: "-Xmx1024m"
     SERVER_PORT: "8080"
     APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
 
@@ -57,6 +57,14 @@ generic-service:
       HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONPRISONERRETRYQUEUE_QUEUE_NAME: "sqs_queue_name"
     sqs-prison-visits-allocation-prisoner-retry-dlq-secret:
       HMPPS_SQS_QUEUES_PRISONVISITSALLOCATIONPRISONERRETRYQUEUE_DLQ_NAME: "sqs_queue_name"
+
+  resources:
+    requests:
+      cpu: 10m
+      memory: 768Mi
+    limits:
+      cpu: 2000m
+      memory: 2048Mi
 
   allowlist:
     groups:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/AllocationService.kt
@@ -3,13 +3,13 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.service
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.AttributeSearchPrisonerDto
 
-@Transactional
 @Service
 class AllocationService(
   private val prisonerSearchClient: PrisonerSearchClient,
@@ -23,6 +23,7 @@ class AllocationService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
+  @Transactional(propagation = Propagation.NOT_SUPPORTED, readOnly = true)
   fun processPrison(jobReference: String, prisonId: String) {
     LOG.info("Entered AllocationService - processPrisonAllocation with job reference - $jobReference , prisonCode - $prisonId")
     prisonService.setVisitOrderAllocationPrisonJobStartTime(jobReference, prisonId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/PrisonerRetryService.kt
@@ -4,6 +4,8 @@ import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.context.annotation.Lazy
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
@@ -34,6 +36,7 @@ class PrisonerRetryService(
     }
   }
 
+  @Transactional(propagation = Propagation.NOT_SUPPORTED, readOnly = true)
   fun handlePrisonerRetry(jobReference: String, prisonerId: String) {
     log.info("handle prisoner - $prisonerId on retry queue")
     val prisoner = prisonerSearchClient.getPrisonerById(prisonerId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/DomainEventListener.kt
@@ -37,7 +37,7 @@ class DomainEventListener(
     if (domainEventProcessingEnabled) {
       val event = objectMapper.readValue(sqsMessage.message, DomainEvent::class.java)
       return CoroutineScope(Context.root().asContextElement()).future {
-        withTimeout(Duration.ofMinutes(10)) {
+        withTimeout(Duration.ofMinutes(5)) {
           val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
             .setSpanKind(SpanKind.CONSUMER)
             .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/VisitAllocationPrisonerRetryQueueListener.kt
@@ -7,11 +7,13 @@ import io.opentelemetry.context.Context
 import io.opentelemetry.extension.kotlin.asContextElement
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.future.future
+import kotlinx.coroutines.time.withTimeout
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.sqs.VisitAllocationPrisonerRetrySqsService.VisitAllocationPrisonerRetryJob
+import java.time.Duration
 import java.util.concurrent.CompletableFuture
 
 @Service
@@ -26,24 +28,32 @@ class VisitAllocationPrisonerRetryQueueListener(private val prisonerRetryService
 
   @SqsListener(PRISON_VISITS_ALLOCATION_PRISONER_RETRY_QUEUE_CONFIG_KEY, factory = "hmppsQueueContainerFactoryProxy", maxConcurrentMessages = "2", maxMessagesPerPoll = "2")
   fun processMessage(visitAllocationPrisonerRetryJob: VisitAllocationPrisonerRetryJob): CompletableFuture<Void?> = CoroutineScope(Context.root().asContextElement()).future {
-    val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
-      .setSpanKind(SpanKind.CONSUMER)
-      .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id
-      .startSpan()
+    withTimeout(Duration.ofMinutes(5)) {
+      val span = tracer.spanBuilder("VisitAllocationDomainEventProcessingJob")
+        .setSpanKind(SpanKind.CONSUMER)
+        .setNoParent() // Force a new trace ID here to stop all jobs being processed under the same operation_id
+        .startSpan()
 
-    val scope = span.makeCurrent()
+      val scope = span.makeCurrent()
 
-    try {
-      log.debug("Processing prisoner on the visits allocation prisoner retry queue - {}", visitAllocationPrisonerRetryJob)
-      prisonerRetryService.handlePrisonerRetry(visitAllocationPrisonerRetryJob.jobReference, visitAllocationPrisonerRetryJob.prisonerId)
-    } catch (t: Throwable) {
-      span.recordException(t)
-      throw t
-    } finally {
-      scope.close()
-      span.end()
+      try {
+        log.debug(
+          "Processing prisoner on the visits allocation prisoner retry queue - {}",
+          visitAllocationPrisonerRetryJob,
+        )
+        prisonerRetryService.handlePrisonerRetry(
+          visitAllocationPrisonerRetryJob.jobReference,
+          visitAllocationPrisonerRetryJob.prisonerId,
+        )
+      } catch (t: Throwable) {
+        span.recordException(t)
+        throw t
+      } finally {
+        scope.close()
+        span.end()
+      }
+
+      null
     }
-
-    null
   }
 }


### PR DESCRIPTION
## What does this PR do?
- Increase heap space
- Increase CPU allocation
- Add explicit transaction boundaries for top level functions
- Add timeouts for co-routine processors (sqs listeners)

## Why?
We are seeing Java "out of heap space" memory exceptions in our preprod environment during allocation job processing. This PR attempts to fix this.