### PR TITLE
Exclude pulling back expired VOs in eager loading to improve performance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/PrisonerDetails.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import org.hibernate.annotations.SQLRestriction
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.PrisonerBalanceDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
@@ -28,6 +29,7 @@ open class PrisonerDetails(
   var lastPvoAllocatedDate: LocalDate?,
 ) {
   @OneToMany(mappedBy = "prisoner", fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST, CascadeType.MERGE], orphanRemoval = true)
+  @SQLRestriction("status <> 'EXPIRED'")
   val visitOrders: MutableList<VisitOrder> = mutableListOf()
 
   @OneToMany(mappedBy = "prisoner", fetch = FetchType.EAGER, cascade = [CascadeType.PERSIST, CascadeType.MERGE], orphanRemoval = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/PrisonerDetailsRetrievalTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/PrisonerDetailsRetrievalTest.kt
@@ -1,0 +1,50 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.integration
+
+import jakarta.persistence.EntityManager
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
+import java.time.LocalDate
+
+@DisplayName("PrisonerDetailsRetrievalTest - Expired VOs excluded")
+class PrisonerDetailsRetrievalTest : IntegrationTestBase() {
+
+  @Autowired
+  private lateinit var service: PrisonerDetailsService
+
+  @Autowired
+  private lateinit var em: EntityManager
+
+  companion object {
+    const val PRISONER_ID = "AA123456"
+  }
+
+  @Test
+  @Transactional
+  fun `When prisoner details are loaded, then expired VOs and PVOs are excluded from the prisoners visitOrders list`() {
+    // Given
+    val prisoner = PrisonerDetails(prisonerId = PRISONER_ID, lastVoAllocatedDate = LocalDate.now().minusDays(14), null)
+    prisoner.visitOrders.add(VisitOrder(type = VisitOrderType.VO, status = VisitOrderStatus.EXPIRED, prisoner = prisoner))
+    prisoner.visitOrders.add(VisitOrder(type = VisitOrderType.VO, status = VisitOrderStatus.AVAILABLE, prisoner = prisoner))
+    prisoner.visitOrders.add(VisitOrder(type = VisitOrderType.PVO, status = VisitOrderStatus.EXPIRED, prisoner = prisoner))
+    prisoner.visitOrders.add(VisitOrder(type = VisitOrderType.PVO, status = VisitOrderStatus.AVAILABLE, prisoner = prisoner))
+
+    em.persist(prisoner)
+    em.flush()
+    em.clear()
+
+    // When
+    val prisonerDetails = service.getPrisonerDetails(PRISONER_ID)!!
+
+    // Then
+    assertThat(prisonerDetails.visitOrders.size).isEqualTo(2)
+    assertThat(prisonerDetails.visitOrders.any { it.status == VisitOrderStatus.EXPIRED }).isFalse
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsBookingMovedTest.kt
@@ -185,7 +185,7 @@ class DomainEventsBookingMovedTest : EventsIntegrationTestBase() {
     await untilAsserted { verify(prisonerDetailsRepository, times(2)).saveAndFlush(any()) }
 
     val prisoner = prisonerDetailsRepository.findById(movedFromPrisonerId).get()
-    assertThat(prisoner.visitOrders.count()).isEqualTo(3)
+    assertThat(prisoner.visitOrders.count()).isEqualTo(0)
     assertThat(prisoner.visitOrders.count { it.status in listOf(VisitOrderStatus.AVAILABLE, VisitOrderStatus.ACCUMULATED) }).isEqualTo(0)
   }
 


### PR DESCRIPTION
## What does this PR do?
Exclude expired VOs from being EAGER loaded when prisoner is loaded in, to avoid bloating the collections with VOs which won't be actioned in any way.