### PR TITLE
bump kotlin lib to a beta version that is proxy aware

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -11,7 +11,7 @@ configurations {
 }
 
 dependencies {
-  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.2.0")
+  implementation("uk.gov.justice.service.hmpps:hmpps-kotlin-spring-boot-starter:2.3.0-beta")
   implementation("org.springframework.boot:spring-boot-starter-webclient")
   implementation("org.springframework.boot:spring-boot-starter-cache")
   implementation("org.springframework.boot:spring-boot-starter-webflux")


### PR DESCRIPTION
This new beta version of the kotlin spring boot starter library includes new features for proxy-aware rest clients. 

This is being tested fully on the prisoner pay service. However, it's necessary to do a test with another service that is not configured with https proxy settings, to ensure the default is not adversely affected. 

Visit Allocation API seems like a reasonable candidate for this testing as its lower stakes than some other APIs and doesn't have a high release frequency so I hope to have a couple of days to monitor it in dev before pushing it live, or more likely publishing the minor lib release 2.3.0-beta -> 2.3.0 and only going live once off the beta version again