### PR TITLE
Implement session VO restriction changes

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 
@@ -38,6 +39,25 @@ class VisitSchedulerClient(
         }
       }
       .block() ?: throw IllegalStateException("timeout response from visit-scheduler for getVisitByReference with reference $visitReference")
+  }
+
+  fun getSessionTemplateByReference(sessionTemplateReference: String): SessionTemplateDto {
+    val uri = "/admin/session-templates/$sessionTemplateReference"
+    return webClient.get()
+      .uri(uri)
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono<SessionTemplateDto>()
+      .onErrorResume { e ->
+        if (!isNotFoundError(e)) {
+          LOG.error("getSessionTemplateByReference Failed for get request $uri")
+          Mono.error(e)
+        } else {
+          LOG.error("getSessionTemplateByReference NOT_FOUND for get request $uri")
+          Mono.error { NotFoundException("Session template not found for reference $sessionTemplateReference, $e") }
+        }
+      }
+      .block() ?: throw IllegalStateException("timeout response from visit-scheduler for getSessionTemplateByReference with reference $sessionTemplateReference")
   }
 
   private fun isNotFoundError(e: Throwable?) = e is WebClientResponseException && e.statusCode == NOT_FOUND

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/SessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/SessionTemplateDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Session template")
+class SessionTemplateDto(
+  @param:Schema(description = "The type of visit order restriction", example = "PVO", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
+)
+
+enum class SessionTemplateVisitOrderRestrictionType {
+  VO_PVO,
+  VO,
+  PVO,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
@@ -16,4 +16,6 @@ class VisitDto(
   @param:JsonAlias("prisonCode")
   @param:Schema(description = "Prison Id", example = "MDI", required = true)
   val prisonCode: String,
+  @param:Schema(description = "Session template reference", example = "v9-d7-ed-7u")
+  val sessionTemplateReference: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.AllocationBatchProc
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeRepaymentReason
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
@@ -524,7 +526,15 @@ class ProcessPrisonerService(
     return visitOrders
   }
 
-  private fun visitAlreadyMapped(dpsPrisonerDetails: PrisonerDetails, visit: VisitDto): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } || dpsPrisonerDetails.negativeVisitOrders.any { it.visitReference == visit.reference }
+  private fun visitAlreadyMapped(dpsPrisonerDetails: PrisonerDetails, visit: VisitDto): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } ||
+    dpsPrisonerDetails.negativeVisitOrders.any { it.visitReference == visit.reference } ||
+    dpsPrisonerDetails.visitOrderHistory.any { history ->
+      history.type == VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT &&
+        history.visitOrderHistoryAttributes.any { attribute ->
+          attribute.attributeType == VisitOrderHistoryAttributeType.VISIT_REFERENCE &&
+            attribute.attributeValue == visit.reference
+        }
+    }
 
   private fun logAllocationBatchProcess(
     dpsPrisonerDetailsAfter: PrisonerDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.PrisonerSnap
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.snapshot
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.AllocationBatchProcessType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeRepaymentReason
@@ -49,13 +50,22 @@ class ProcessPrisonerService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun processPrisonerVisitOrderUsage(visit: VisitDto): UUID? {
+  fun processPrisonerVisitOrderUsage(
+    visit: VisitDto,
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType? = null,
+  ): UUID? {
     val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetailsWithLock(visit.prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
 
     // Due to our SQS queues being "At least once delivery", this specific event needs to return early if this visit has already been mapped.
     if (visitAlreadyMapped(dpsPrisonerDetails, visit)) {
       LOG.info("Duplicate request to map a visit booking (${visit.reference}) to a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Exiting early.")
+      return null
+    }
+
+    if (visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE) {
+      LOG.info("Visit booking (${visit.reference}) does not require a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Logging history only.")
+      visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference)
       return null
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.VisitSchedulerClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
@@ -43,8 +46,7 @@ class VisitBookedEventHandler(
       LOG.info("Prisoner ${prisoner.prisonerId} is in ${prisoner.prisonId} which is enabled for DPS, processing event")
 
       if (prisoner.convictedStatus == CONVICTED) {
-        val visitOrderRestriction = visit.sessionTemplateReference
-          ?.let { visitSchedulerClient.getSessionTemplateByReference(it).visitOrderRestriction }
+        val visitOrderRestriction = getVisitOrderRestriction(visit)
         val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, visitOrderRestriction)
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
@@ -59,4 +61,14 @@ class VisitBookedEventHandler(
       LOG.info("Prison ${prisoner.prisonId} is not enabled for DPS, skipping processing")
     }
   }
+
+  private fun getVisitOrderRestriction(visit: VisitDto): SessionTemplateVisitOrderRestrictionType? = visit.sessionTemplateReference
+    ?.let { sessionTemplateReference ->
+      try {
+        visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction
+      } catch (e: NotFoundException) {
+        LOG.warn("Session template $sessionTemplateReference not found for visit ${visit.reference}. Continuing with default visit order usage.", e)
+        null
+      }
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -43,7 +43,9 @@ class VisitBookedEventHandler(
       LOG.info("Prisoner ${prisoner.prisonerId} is in ${prisoner.prisonId} which is enabled for DPS, processing event")
 
       if (prisoner.convictedStatus == CONVICTED) {
-        val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit)
+        val visitOrderRestriction = visit.sessionTemplateReference
+          ?.let { visitSchedulerClient.getSessionTemplateByReference(it).visitOrderRestriction }
+        val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, visitOrderRestriction)
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
           if (changeLog != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -21,12 +21,16 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.Sessi
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistory
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistoryAttributes
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
@@ -329,6 +333,40 @@ class ProcessPrisonerServiceTest {
     assertThat(dpsPrisoner.negativeVisitOrders).isEmpty()
     verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference)
     verifyNoInteractions(changeLogService, telemetryClientService)
+  }
+
+  @Test
+  fun `Prisoner VO consumption - Given session template uses no visit order and visit history exists, when processPrisonerVisitOrderUsage is called, then no extra processing is done`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val prisonId = "HEI"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId)
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    val visitOrderHistory = VisitOrderHistory(
+      type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT,
+      prisoner = dpsPrisoner,
+      voBalance = 1,
+      pvoBalance = 0,
+      userName = "SYSTEM",
+    )
+    visitOrderHistory.visitOrderHistoryAttributes.add(
+      VisitOrderHistoryAttributes(
+        visitOrderHistory = visitOrderHistory,
+        attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE,
+        attributeValue = visitReference,
+      ),
+    )
+    dpsPrisoner.visitOrderHistory.add(visitOrderHistory)
+
+    // WHEN
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    verifyNoInteractions(visitOrderHistoryService, changeLogService, telemetryClientService)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi
 
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -9,15 +10,19 @@ import org.mockito.Mockito.anyMap
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
@@ -301,6 +306,29 @@ class ProcessPrisonerServiceTest {
     // THEN
     verify(changeLogService).createLogAllocationUsedByVisit(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_CONSUMED_BY_VISIT), anyMap())
+  }
+
+  @Test
+  fun `Prisoner VO consumption - Given session template uses no visit order, when processPrisonerVisitOrderUsage is called, then only history is created`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val prisonId = "HEI"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId)
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    dpsPrisoner.visitOrders.add(visitOrdersUtil.createAvailableVisitOrder(dpsPrisoner, VisitOrderType.VO))
+
+    // WHEN
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    assertThat(dpsPrisoner.visitOrders).allMatch { it.status == VisitOrderStatus.AVAILABLE && it.visitReference == null }
+    assertThat(dpsPrisoner.negativeVisitOrders).isEmpty()
+    verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference)
+    verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -163,6 +163,70 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
   }
 
   @Test
+  fun `when domain event visit booked is found and session template is not found, then PVO is consumed`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "missing-session-template-ref"
+
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.VO, 2, dpsPrisoner))
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.PVO, 1, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(
+      ChangeLog(
+        changeTimestamp = LocalDateTime.now().minusSeconds(1),
+        changeType = ChangeLogType.BATCH_PROCESS,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Random existing changeLog",
+        prisoner = dpsPrisoner,
+        visitOrderBalance = 2,
+        privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
+      ),
+    )
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_BOOKED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_BOOKED_EVENT_TYPE.value, domainEvent)
+
+    // And
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, null, HttpStatus.NOT_FOUND)
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
+    await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(2)
+    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
+
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList.size).isEqualTo(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+  }
+
+  @Test
   fun `when domain event visit booked is found, and no PVO is available, then VO is consumed`() {
     // Given
     val visitReference = "ab-cd-ef-gh"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -8,9 +8,13 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_REFERENCE
@@ -76,7 +80,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -92,6 +96,70 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
     assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+  }
+
+  @Test
+  fun `when domain event visit booked is found and session template uses no visit order, then only history is created`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "session-template-ref"
+
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.VO, 2, dpsPrisoner))
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.PVO, 1, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(
+      ChangeLog(
+        changeTimestamp = LocalDateTime.now().minusSeconds(1),
+        changeType = ChangeLogType.BATCH_PROCESS,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Random existing changeLog",
+        prisoner = dpsPrisoner,
+        visitOrderBalance = 2,
+        privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
+      ),
+    )
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_BOOKED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_BOOKED_EVENT_TYPE.value, domainEvent)
+
+    // And
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, SessionTemplateDto(SessionTemplateVisitOrderRestrictionType.NONE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), eq(SessionTemplateVisitOrderRestrictionType.NONE)) }
+    await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
+    await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(3)
+    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
+
+    val changeLogs = changeLogRepository.findAll()
+    assertThat(changeLogs.none { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }).isTrue()
+
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList.size).isEqualTo(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
   }
 
   @Test
@@ -137,7 +205,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -197,7 +265,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -260,7 +328,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -312,7 +380,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -374,7 +442,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
@@ -244,7 +244,12 @@ abstract class EventsIntegrationTestBase {
 
   protected fun createVisitBalancesDto(remainingVo: Int, remainingPvo: Int, latestIepAdjustDate: LocalDate? = null, latestPrivIepAdjustDate: LocalDate? = null): VisitBalancesDto = VisitBalancesDto(remainingVo, remainingPvo, latestIepAdjustDate, latestPrivIepAdjustDate)
 
-  protected fun createVisitDto(visitReference: String, prisonerId: String, prisonId: String): VisitDto = VisitDto(visitReference, prisonerId, prisonId)
+  protected fun createVisitDto(
+    visitReference: String,
+    prisonerId: String,
+    prisonId: String,
+    sessionTemplateReference: String? = null,
+  ): VisitDto = VisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
 
   private fun createAdditionalInformationJson(jsonValues: Map<String, Any>): String {
     val builder = StringBuilder()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/VisitSchedulerMockServer.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.MockUtils.Companion.getJsonString
 
@@ -32,6 +33,30 @@ class VisitSchedulerMockServer : WireMockServer(8097) {
             responseBuilder
               .withStatus(HttpStatus.OK.value())
               .withBody(getJsonString(visit))
+          },
+        ),
+    )
+  }
+
+  fun stubGetSessionTemplateByReference(sessionTemplateReference: String, sessionTemplate: SessionTemplateDto?, httpStatus: HttpStatus? = null) {
+    val responseBuilder = aResponse()
+      .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+
+    stubFor(
+      get("/admin/session-templates/$sessionTemplateReference")
+        .willReturn(
+          if (sessionTemplate == null) {
+            if (httpStatus != null) {
+              responseBuilder
+                .withStatus(httpStatus.value())
+            } else {
+              responseBuilder
+                .withStatus(HttpStatus.NOT_FOUND.value())
+            }
+          } else {
+            responseBuilder
+              .withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(sessionTemplate))
           },
         ),
     )


### PR DESCRIPTION
Handle if a session restriction exists and is set to NONE, do not deduct a visit order from the prisoners balance but still generate a visit_order_history log entry for visibility.