### PR TITLE
VB-6495 - Implement session vo restrictions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
@@ -50,7 +50,7 @@ class VisitSchedulerClient(
       .bodyToMono<SessionTemplateDto>()
       .onErrorResume { e ->
         if (!isNotFoundError(e)) {
-          LOG.error("getSessionTemplateByReference Failed for get request $uri")
+          LOG.error("getSessionTemplateByReference Failed for get request $uri", e)
           Mono.error(e)
         } else {
           LOG.debug("getSessionTemplateByReference NOT_FOUND for get request $uri")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
@@ -53,7 +53,7 @@ class VisitSchedulerClient(
           LOG.error("getSessionTemplateByReference Failed for get request $uri")
           Mono.error(e)
         } else {
-          LOG.error("getSessionTemplateByReference NOT_FOUND for get request $uri")
+          LOG.debug("getSessionTemplateByReference NOT_FOUND for get request $uri")
           Mono.error { NotFoundException("Session template not found for reference $sessionTemplateReference, $e") }
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/clients/VisitSchedulerClient.kt
@@ -10,6 +10,7 @@ import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 
@@ -38,6 +39,25 @@ class VisitSchedulerClient(
         }
       }
       .block() ?: throw IllegalStateException("timeout response from visit-scheduler for getVisitByReference with reference $visitReference")
+  }
+
+  fun getSessionTemplateByReference(sessionTemplateReference: String): SessionTemplateDto {
+    val uri = "/admin/session-templates/$sessionTemplateReference"
+    return webClient.get()
+      .uri(uri)
+      .accept(MediaType.APPLICATION_JSON)
+      .retrieve()
+      .bodyToMono<SessionTemplateDto>()
+      .onErrorResume { e ->
+        if (!isNotFoundError(e)) {
+          LOG.error("getSessionTemplateByReference Failed for get request $uri")
+          Mono.error(e)
+        } else {
+          LOG.error("getSessionTemplateByReference NOT_FOUND for get request $uri")
+          Mono.error { NotFoundException("Session template not found for reference $sessionTemplateReference, $e") }
+        }
+      }
+      .block() ?: throw IllegalStateException("timeout response from visit-scheduler for getSessionTemplateByReference with reference $sessionTemplateReference")
   }
 
   private fun isNotFoundError(e: Throwable?) = e is WebClientResponseException && e.statusCode == NOT_FOUND

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/SessionTemplateDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/SessionTemplateDto.kt
@@ -1,0 +1,16 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Session template")
+class SessionTemplateDto(
+  @param:Schema(description = "The type of visit order restriction", example = "PVO", required = true)
+  val visitOrderRestriction: SessionTemplateVisitOrderRestrictionType,
+)
+
+enum class SessionTemplateVisitOrderRestrictionType {
+  VO_PVO,
+  VO,
+  PVO,
+  NONE,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/dto/visit/scheduler/VisitDto.kt
@@ -16,4 +16,6 @@ class VisitDto(
   @param:JsonAlias("prisonCode")
   @param:Schema(description = "Prison Id", example = "MDI", required = true)
   val prisonCode: String,
+  @param:Schema(description = "Session template reference", example = "v9-d7-ed-7u")
+  val sessionTemplateReference: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/VisitOrderHistoryAttributeType.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/enums/VisitOrderHistoryAttributeType.kt
@@ -6,4 +6,5 @@ enum class VisitOrderHistoryAttributeType {
   OLD_PRISONER_ID,
   NEW_PRISONER_ID,
   ADJUSTMENT_REASON_TYPE,
+  VISIT_ORDER_TYPE_USED,
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrderHistoryAttributes.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/model/entity/VisitOrderHistoryAttributes.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.model.entity
 
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
@@ -22,6 +24,7 @@ open class VisitOrderHistoryAttributes(
   var visitOrderHistory: VisitOrderHistory,
 
   @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
   val attributeType: VisitOrderHistoryAttributeType,
 
   @Column(nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderHistoryRepository.kt
@@ -10,4 +10,26 @@ import java.time.LocalDateTime
 interface VisitOrderHistoryRepository : JpaRepository<VisitOrderHistory, Long> {
   @Query("SELECT voh FROM VisitOrderHistory voh WHERE voh.prisoner.prisonerId = :prisonerId and voh.createdTimestamp >= :fromDateTime order by voh.id asc")
   fun findVisitOrderHistoryByPrisonerIdAfterFromDateOrderByIdAsc(prisonerId: String, fromDateTime: LocalDateTime): List<VisitOrderHistory>
+
+  @Query(
+    value =
+    """
+    SELECT EXISTS (
+      SELECT 1
+      FROM visit_order_history voh
+      JOIN visit_order_history_attributes attribute ON attribute.visit_order_history_id = voh.id
+      WHERE voh.prisoner_id = :prisonerId
+      AND voh.type = :visitOrderHistoryType
+      AND attribute.attribute_type = :attributeType
+      AND attribute.attribute_value = :visitReference
+    )
+    """,
+    nativeQuery = true,
+  )
+  fun existsByPrisonerIdAndTypeAndVisitReferenceAttribute(
+    prisonerId: String,
+    visitOrderHistoryType: String,
+    attributeType: String,
+    visitReference: String,
+  ): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderHistoryRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/repository/VisitOrderHistoryRepository.kt
@@ -3,6 +3,8 @@ package uk.gov.justice.digital.hmpps.visitallocationapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistory
 import java.time.LocalDateTime
 
@@ -12,24 +14,20 @@ interface VisitOrderHistoryRepository : JpaRepository<VisitOrderHistory, Long> {
   fun findVisitOrderHistoryByPrisonerIdAfterFromDateOrderByIdAsc(prisonerId: String, fromDateTime: LocalDateTime): List<VisitOrderHistory>
 
   @Query(
-    value =
     """
-    SELECT EXISTS (
-      SELECT 1
-      FROM visit_order_history voh
-      JOIN visit_order_history_attributes attribute ON attribute.visit_order_history_id = voh.id
-      WHERE voh.prisoner_id = :prisonerId
-      AND voh.type = :visitOrderHistoryType
-      AND attribute.attribute_type = :attributeType
-      AND attribute.attribute_value = :visitReference
-    )
-    """,
-    nativeQuery = true,
+    SELECT CASE WHEN COUNT(voh) > 0 THEN true ELSE false END
+    FROM VisitOrderHistory voh
+    JOIN voh.visitOrderHistoryAttributes attribute
+    WHERE voh.prisoner.prisonerId = :prisonerId
+    AND voh.type = :visitOrderHistoryType
+    AND attribute.attributeType = :attributeType
+    AND attribute.attributeValue = :visitReference
+  """,
   )
   fun existsByPrisonerIdAndTypeAndVisitReferenceAttribute(
     prisonerId: String,
-    visitOrderHistoryType: String,
-    attributeType: String,
+    visitOrderHistoryType: VisitOrderHistoryType,
+    attributeType: VisitOrderHistoryAttributeType,
     visitReference: String,
   ): Boolean
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -18,8 +18,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.AllocationBatchProc
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeRepaymentReason
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
@@ -60,7 +58,7 @@ class ProcessPrisonerService(
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
 
     // Due to our SQS queues being "At least once delivery", this specific event needs to return early if this visit has already been mapped.
-    if (visitAlreadyMapped(dpsPrisonerDetails, visit)) {
+    if (visitAlreadyMapped(dpsPrisonerDetails, visit, visitOrderRestriction)) {
       LOG.info("Duplicate request to map a visit booking (${visit.reference}) to a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Exiting early.")
       return null
     }
@@ -526,15 +524,16 @@ class ProcessPrisonerService(
     return visitOrders
   }
 
-  private fun visitAlreadyMapped(dpsPrisonerDetails: PrisonerDetails, visit: VisitDto): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } ||
+  private fun visitAlreadyMapped(
+    dpsPrisonerDetails: PrisonerDetails,
+    visit: VisitDto,
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType?,
+  ): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } ||
     dpsPrisonerDetails.negativeVisitOrders.any { it.visitReference == visit.reference } ||
-    dpsPrisonerDetails.visitOrderHistory.any { history ->
-      history.type == VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT &&
-        history.visitOrderHistoryAttributes.any { attribute ->
-          attribute.attributeType == VisitOrderHistoryAttributeType.VISIT_REFERENCE &&
-            attribute.attributeValue == visit.reference
-        }
-    }
+    (
+      visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE &&
+        visitOrderHistoryService.allocationUsedByVisitExists(dpsPrisonerDetails.prisonerId, visit.reference)
+      )
 
   private fun logAllocationBatchProcess(
     dpsPrisonerDetailsAfter: PrisonerDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -118,6 +118,11 @@ class ProcessPrisonerService(
     val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetailsWithLock(visit.prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
 
+    if (visitOrderHistoryService.allocationRefundedByVisitCancelledExists(dpsPrisonerDetails.prisonerId, visit.reference)) {
+      LOG.info("Duplicate request to refund a visit order for cancelled visit (${visit.reference}) for prisoner ${dpsPrisonerDetails.prisonerId}. Exiting early.")
+      return null
+    }
+
     if (visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE) {
       LOG.info("Visit cancellation (${visit.reference}) does not require a visit order refund for prisoner ${visit.prisonerId}. Logging history only.")
       visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference, "NONE")
@@ -159,7 +164,7 @@ class ProcessPrisonerService(
         // If the original negative VO has already been repaid by something else (such as allocation),
         // find any negative USED VO, repay the first one.
         dpsPrisonerDetails.negativeVisitOrders.any { it.status == NegativeVisitOrderStatus.USED } -> {
-          dpsPrisonerDetails.negativeVisitOrders.first().apply {
+          dpsPrisonerDetails.negativeVisitOrders.first { it.status == NegativeVisitOrderStatus.USED }.apply {
             visitOrderTypeUsed = type
             status = NegativeVisitOrderStatus.REPAID
             repaidDate = LocalDate.now()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -18,6 +18,8 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.AllocationBatchProc
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeRepaymentReason
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
@@ -524,7 +526,15 @@ class ProcessPrisonerService(
     return visitOrders
   }
 
-  private fun visitAlreadyMapped(dpsPrisonerDetails: PrisonerDetails, visit: VisitDto): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } || dpsPrisonerDetails.negativeVisitOrders.any { it.visitReference == visit.reference }
+  private fun visitAlreadyMapped(dpsPrisonerDetails: PrisonerDetails, visit: VisitDto): Boolean = dpsPrisonerDetails.visitOrders.any { it.visitReference == visit.reference } ||
+    dpsPrisonerDetails.negativeVisitOrders.any { it.visitReference == visit.reference } ||
+    dpsPrisonerDetails.visitOrderHistory.any { history ->
+      history.type == VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT &&
+        history.visitOrderHistoryAttributes.any { attribute ->
+          attribute.attributeType == VisitOrderHistoryAttributeType.VISIT_REFERENCE &&
+            attribute.attributeValue == visit.reference
+        }
+    }
 
   private fun logAllocationBatchProcess(
     dpsPrisonerDetailsAfter: PrisonerDetails,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.PrisonerSnap
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.snapshots.snapshot
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.AllocationBatchProcessType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeRepaymentReason
@@ -49,13 +50,22 @@ class ProcessPrisonerService(
     val LOG: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun processPrisonerVisitOrderUsage(visit: VisitDto): UUID? {
+  fun processPrisonerVisitOrderUsage(
+    visit: VisitDto,
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType? = null,
+  ): UUID? {
     val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetailsWithLock(visit.prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
 
     // Due to our SQS queues being "At least once delivery", this specific event needs to return early if this visit has already been mapped.
     if (visitAlreadyMapped(dpsPrisonerDetails, visit)) {
       LOG.info("Duplicate request to map a visit booking (${visit.reference}) to a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Exiting early.")
+      return null
+    }
+
+    if (visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE) {
+      LOG.info("Visit booking (${visit.reference}) does not require a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Logging history only.")
+      visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference)
       return null
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -65,7 +65,7 @@ class ProcessPrisonerService(
 
     if (visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE) {
       LOG.info("Visit booking (${visit.reference}) does not require a visit order for prisoner ${dpsPrisonerDetails.prisonerId}. Logging history only.")
-      visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference)
+      visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference, "NONE")
       return null
     }
 
@@ -95,7 +95,7 @@ class ProcessPrisonerService(
       dpsPrisonerDetails.negativeVisitOrders.add(negativeVo)
     }
 
-    visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference)
+    visitOrderHistoryService.logAllocationUsedByVisit(dpsPrisonerDetails, visit.reference, selected?.type?.name ?: VisitOrderType.VO.name)
     val changeLog = changeLogService.createLogAllocationUsedByVisit(dpsPrisonerDetails, visit.reference)
     dpsPrisonerDetails.changeLogs.add(changeLog)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/ProcessPrisonerService.kt
@@ -111,17 +111,28 @@ class ProcessPrisonerService(
     return changeLog.reference
   }
 
-  fun processPrisonerVisitOrderRefund(visit: VisitDto): UUID? {
+  fun processPrisonerVisitOrderRefund(
+    visit: VisitDto,
+    visitOrderRestriction: SessionTemplateVisitOrderRestrictionType? = null,
+  ): UUID? {
     val dpsPrisonerDetails = prisonerDetailsService.getPrisonerDetailsWithLock(visit.prisonerId)
       ?: prisonerDetailsService.createPrisonerDetails(visit.prisonerId, LocalDate.now().minusDays(14), null)
+
+    if (visitOrderRestriction == SessionTemplateVisitOrderRestrictionType.NONE) {
+      LOG.info("Visit cancellation (${visit.reference}) does not require a visit order refund for prisoner ${visit.prisonerId}. Logging history only.")
+      visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference, "NONE")
+      return null
+    }
 
     // Find the VO used by the visit.
     val voUsedForVisit = dpsPrisonerDetails.visitOrders
       .firstOrNull { it.visitReference == visit.reference }
+    var visitOrderTypeUsed = voUsedForVisit?.type ?: VisitOrderType.VO
 
     if (voUsedForVisit != null) {
       if (voUsedForVisit.type == VisitOrderType.VO && hasPrisonerReachedVoCap(dpsPrisonerDetails)) {
         LOG.info("Prisoner ${dpsPrisonerDetails.prisonerId} already has the maximum number of VOs. Refund for visit ${visit.reference} will not be processed.")
+        visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference, visitOrderTypeUsed.name)
         return null
       }
 
@@ -137,6 +148,7 @@ class ProcessPrisonerService(
         // Aim to repay the original negative VO which was used by the visit.
         negativeVoUsedForVisit != null && negativeVoUsedForVisit.status == NegativeVisitOrderStatus.USED -> {
           LOG.info("Prisoner ${dpsPrisonerDetails.prisonerId} - refunding VO by removing negative VO")
+          visitOrderTypeUsed = negativeVoUsedForVisit.type
           negativeVoUsedForVisit.apply {
             status = NegativeVisitOrderStatus.REPAID
             repaidDate = LocalDate.now()
@@ -148,6 +160,7 @@ class ProcessPrisonerService(
         // find any negative USED VO, repay the first one.
         dpsPrisonerDetails.negativeVisitOrders.any { it.status == NegativeVisitOrderStatus.USED } -> {
           dpsPrisonerDetails.negativeVisitOrders.first().apply {
+            visitOrderTypeUsed = type
             status = NegativeVisitOrderStatus.REPAID
             repaidDate = LocalDate.now()
             repaidReason = NegativeRepaymentReason.VISIT_ORDER_REFUND
@@ -156,6 +169,7 @@ class ProcessPrisonerService(
 
         hasPrisonerReachedVoCap(dpsPrisonerDetails) -> {
           LOG.info("Prisoner ${dpsPrisonerDetails.prisonerId} already has the maximum number of VOs. Refund for visit ${visit.reference} will not be processed.")
+          visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference, visitOrderTypeUsed.name)
           return null
         }
 
@@ -166,7 +180,7 @@ class ProcessPrisonerService(
       }
     }
 
-    visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference)
+    visitOrderHistoryService.logAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference, visitOrderTypeUsed.name)
     val changeLog = changeLogService.createLogAllocationRefundedByVisitCancelled(dpsPrisonerDetails, visit.reference)
     dpsPrisonerDetails.changeLogs.add(changeLog)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
@@ -46,6 +46,13 @@ class VisitOrderHistoryService(
     visitReference = visitReference,
   )
 
+  fun allocationRefundedByVisitCancelledExists(prisonerId: String, visitReference: String): Boolean = visitOrderHistoryRepository.existsByPrisonerIdAndTypeAndVisitReferenceAttribute(
+    prisonerId = prisonerId,
+    visitOrderHistoryType = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
+    attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE,
+    visitReference = visitReference,
+  )
+
   fun logMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto, dpsPrisoner: PrisonerDetails): VisitOrderHistory {
     logger.info("Logging migration to visit_order_history table for prisoner ${migrationChangeDto.prisonerId}, migration - $migrationChangeDto")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
@@ -97,9 +97,12 @@ class VisitOrderHistoryService(
     )
   }
 
-  fun logAllocationUsedByVisit(dpsPrisoner: PrisonerDetails, visitReference: String): VisitOrderHistory {
+  fun logAllocationUsedByVisit(dpsPrisoner: PrisonerDetails, visitReference: String, visitOrderTypeUsed: String): VisitOrderHistory {
     logger.info("Logging to visit_order_history table for prisoner ${dpsPrisoner.prisonerId} - logAllocationUsedByVisit")
-    val attributes = mapOf(VisitOrderHistoryAttributeType.VISIT_REFERENCE to visitReference)
+    val attributes = mapOf(
+      VisitOrderHistoryAttributeType.VISIT_REFERENCE to visitReference,
+      VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED to visitOrderTypeUsed,
+    )
 
     return createVisitOrderHistory(
       dpsPrisoner = dpsPrisoner,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
@@ -39,6 +39,14 @@ class VisitOrderHistoryService(
 
   fun getVisitOrderHistoryForPrisoner(prisonerId: String, fromDate: LocalDate): List<VisitOrderHistoryDto> = visitOrderHistoryRepository.findVisitOrderHistoryByPrisonerIdAfterFromDateOrderByIdAsc(prisonerId, fromDate.atStartOfDay()).map { VisitOrderHistoryDto(it) }
 
+  fun allocationUsedByVisitExists(prisonerId: String, visitReference: String): Boolean = visitOrderHistoryRepository.existsByPrisonerIdAndTypeAndVisitReferenceAttribute(
+    prisonerId = prisonerId,
+    visitOrderHistoryType = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT.name,
+    // VisitOrderHistoryAttributes.attributeType currently uses JPA's default ordinal enum mapping.
+    attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE.ordinal.toString(),
+    visitReference = visitReference,
+  )
+
   fun logMigrationChange(migrationChangeDto: VisitAllocationPrisonerMigrationDto, dpsPrisoner: PrisonerDetails): VisitOrderHistory {
     logger.info("Logging migration to visit_order_history table for prisoner ${migrationChangeDto.prisonerId}, migration - $migrationChangeDto")
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
@@ -41,9 +41,8 @@ class VisitOrderHistoryService(
 
   fun allocationUsedByVisitExists(prisonerId: String, visitReference: String): Boolean = visitOrderHistoryRepository.existsByPrisonerIdAndTypeAndVisitReferenceAttribute(
     prisonerId = prisonerId,
-    visitOrderHistoryType = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT.name,
-    // VisitOrderHistoryAttributes.attributeType currently uses JPA's default ordinal enum mapping.
-    attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE.ordinal.toString(),
+    visitOrderHistoryType = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT,
+    attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE,
     visitReference = visitReference,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/VisitOrderHistoryService.kt
@@ -112,9 +112,12 @@ class VisitOrderHistoryService(
     )
   }
 
-  fun logAllocationRefundedByVisitCancelled(dpsPrisoner: PrisonerDetails, visitReference: String): VisitOrderHistory {
+  fun logAllocationRefundedByVisitCancelled(dpsPrisoner: PrisonerDetails, visitReference: String, visitOrderTypeUsed: String): VisitOrderHistory {
     logger.info("Logging to visit_order_history table for prisoner ${dpsPrisoner.prisonerId} - logAllocationRefundedByVisitCancelled")
-    val attributes = mapOf(VisitOrderHistoryAttributeType.VISIT_REFERENCE to visitReference)
+    val attributes = mapOf(
+      VisitOrderHistoryAttributeType.VISIT_REFERENCE to visitReference,
+      VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED to visitOrderTypeUsed,
+    )
 
     return createVisitOrderHistory(
       dpsPrisoner = dpsPrisoner,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -9,7 +9,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchCli
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.VisitSchedulerClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
-import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
@@ -63,12 +62,5 @@ class VisitBookedEventHandler(
   }
 
   private fun getVisitOrderRestriction(visit: VisitDto): SessionTemplateVisitOrderRestrictionType? = visit.sessionTemplateReference
-    ?.let { sessionTemplateReference ->
-      try {
-        visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction
-      } catch (e: NotFoundException) {
-        LOG.warn("Session template $sessionTemplateReference not found for visit ${visit.reference}. Continuing with default visit order usage.")
-        null
-      }
-    }
+    ?.let { sessionTemplateReference -> visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -7,6 +7,9 @@ import org.springframework.stereotype.Service
 import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.VisitSchedulerClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.exception.NotFoundException
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
@@ -43,8 +46,7 @@ class VisitBookedEventHandler(
       LOG.info("Prisoner ${prisoner.prisonerId} is in ${prisoner.prisonId} which is enabled for DPS, processing event")
 
       if (prisoner.convictedStatus == CONVICTED) {
-        val visitOrderRestriction = visit.sessionTemplateReference
-          ?.let { visitSchedulerClient.getSessionTemplateByReference(it).visitOrderRestriction }
+        val visitOrderRestriction = getVisitOrderRestriction(visit)
         val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, visitOrderRestriction)
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
@@ -59,4 +61,14 @@ class VisitBookedEventHandler(
       LOG.info("Prison ${prisoner.prisonId} is not enabled for DPS, skipping processing")
     }
   }
+
+  private fun getVisitOrderRestriction(visit: VisitDto): SessionTemplateVisitOrderRestrictionType? = visit.sessionTemplateReference
+    ?.let { sessionTemplateReference ->
+      try {
+        visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction
+      } catch (e: NotFoundException) {
+        LOG.warn("Session template $sessionTemplateReference not found for visit ${visit.reference}. Continuing with default visit order usage.", e)
+        null
+      }
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -43,7 +43,9 @@ class VisitBookedEventHandler(
       LOG.info("Prisoner ${prisoner.prisonerId} is in ${prisoner.prisonId} which is enabled for DPS, processing event")
 
       if (prisoner.convictedStatus == CONVICTED) {
-        val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit)
+        val visitOrderRestriction = visit.sessionTemplateReference
+          ?.let { visitSchedulerClient.getSessionTemplateByReference(it).visitOrderRestriction }
+        val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, visitOrderRestriction)
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(prisoner.prisonerId, changeLogReference)
           if (changeLog != null) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitBookedEventHandler.kt
@@ -67,7 +67,7 @@ class VisitBookedEventHandler(
       try {
         visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction
       } catch (e: NotFoundException) {
-        LOG.warn("Session template $sessionTemplateReference not found for visit ${visit.reference}. Continuing with default visit order usage.", e)
+        LOG.warn("Session template $sessionTemplateReference not found for visit ${visit.reference}. Continuing with default visit order usage.")
         null
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/service/listener/events/handlers/VisitCancelledEventHandler.kt
@@ -9,6 +9,8 @@ import tools.jackson.databind.ObjectMapper
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.VisitSchedulerClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ProcessPrisonerService
@@ -48,7 +50,8 @@ class VisitCancelledEventHandler(
       LOG.info("Prisoner ${prisoner.prisonerId} is in ${prisoner.prisonId} which is enabled for DPS, processing event")
 
       if (prisoner.convictedStatus == CONVICTED) {
-        val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit)
+        val visitOrderRestriction = getVisitOrderRestriction(visit)
+        val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit, visitOrderRestriction)
 
         if (changeLogReference != null) {
           val changeLog = changeLogService.findChangeLogForPrisonerByReference(visit.prisonerId, changeLogReference)
@@ -63,6 +66,9 @@ class VisitCancelledEventHandler(
       LOG.info("Prison ${prisoner.prisonId} is not enabled for DPS, skipping processing")
     }
   }
+
+  private fun getVisitOrderRestriction(visit: VisitDto): SessionTemplateVisitOrderRestrictionType? = visit.sessionTemplateReference
+    ?.let { sessionTemplateReference -> visitSchedulerClient.getSessionTemplateByReference(sessionTemplateReference).visitOrderRestriction }
 
   private fun getPrisonerOrHandleMergedPrisoner(prisonerId: String): PrisonerDto? {
     try {

--- a/src/main/resources/db/migration/V2_3__convert_visit_order_history_attribute_type_to_string.sql
+++ b/src/main/resources/db/migration/V2_3__convert_visit_order_history_attribute_type_to_string.sql
@@ -1,0 +1,10 @@
+UPDATE visit_order_history_attributes
+SET attribute_type = CASE attribute_type
+    WHEN '0' THEN 'VISIT_REFERENCE'
+    WHEN '1' THEN 'INCENTIVE_LEVEL'
+    WHEN '2' THEN 'OLD_PRISONER_ID'
+    WHEN '3' THEN 'NEW_PRISONER_ID'
+    WHEN '4' THEN 'ADJUSTMENT_REASON_TYPE'
+    ELSE attribute_type
+END
+WHERE attribute_type IN ('0', '1', '2', '3', '4');

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.anyMap
+import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.eq
@@ -21,16 +22,12 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.Sessi
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
-import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistory
-import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistoryAttributes
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
@@ -343,30 +340,18 @@ class ProcessPrisonerServiceTest {
     val prisonId = "HEI"
     val visit = createVisitDto(visitReference, prisonerId, prisonId)
     val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
-    val visitOrderHistory = VisitOrderHistory(
-      type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT,
-      prisoner = dpsPrisoner,
-      voBalance = 1,
-      pvoBalance = 0,
-      userName = "SYSTEM",
-    )
-    visitOrderHistory.visitOrderHistoryAttributes.add(
-      VisitOrderHistoryAttributes(
-        visitOrderHistory = visitOrderHistory,
-        attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE,
-        attributeValue = visitReference,
-      ),
-    )
-    dpsPrisoner.visitOrderHistory.add(visitOrderHistory)
 
     // WHEN
     whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+    whenever(visitOrderHistoryService.allocationUsedByVisitExists(prisonerId, visitReference)).thenReturn(true)
 
     val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, SessionTemplateVisitOrderRestrictionType.NONE)
 
     // THEN
     assertThat(changeLogReference).isNull()
-    verifyNoInteractions(visitOrderHistoryService, changeLogService, telemetryClientService)
+    verify(visitOrderHistoryService).allocationUsedByVisitExists(prisonerId, visitReference)
+    verify(visitOrderHistoryService, never()).logAllocationUsedByVisit(dpsPrisoner, visitReference)
+    verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -452,6 +452,57 @@ class ProcessPrisonerServiceTest {
     verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
+  @Test
+  fun `Prisoner VO refund - Given refund history exists for session template using no visit order, no extra processing is done`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val visit = createVisitDto(visitReference, prisonerId, "HEI")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+    whenever(visitOrderHistoryService.allocationRefundedByVisitCancelledExists(prisonerId, visitReference)).thenReturn(true)
+
+    // WHEN
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    verify(visitOrderHistoryService).allocationRefundedByVisitCancelledExists(prisonerId, visitReference)
+    verify(visitOrderHistoryService, never()).logAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference, "NONE")
+    verifyNoInteractions(changeLogService, telemetryClientService)
+  }
+
+  @Test
+  fun `Prisoner VO refund - Given refund history exists for visit with a used VO, no extra processing is done`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val visit = createVisitDto(visitReference, prisonerId, "HEI")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    val usedVisitOrder = VisitOrder(
+      type = VisitOrderType.VO,
+      status = VisitOrderStatus.USED,
+      visitReference = visitReference,
+      prisoner = dpsPrisoner,
+    )
+    dpsPrisoner.visitOrders.add(usedVisitOrder)
+
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+    whenever(visitOrderHistoryService.allocationRefundedByVisitCancelledExists(prisonerId, visitReference)).thenReturn(true)
+
+    // WHEN
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    assertThat(usedVisitOrder.status).isEqualTo(VisitOrderStatus.USED)
+    assertThat(usedVisitOrder.visitReference).isEqualTo(visitReference)
+    verify(visitOrderHistoryService).allocationRefundedByVisitCancelledExists(prisonerId, visitReference)
+    verify(visitOrderHistoryService, never()).logAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference, VisitOrderType.VO.name)
+    verifyNoInteractions(changeLogService, telemetryClientService)
+  }
+
   // Prisoner Reset balance \\
 
   /**

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSour
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrder
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
@@ -369,6 +370,14 @@ class ProcessPrisonerServiceTest {
     val prisonId = "HEI"
     val visit = createVisitDto(visitReference, prisonerId, prisonId)
     val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    dpsPrisoner.visitOrders.add(
+      VisitOrder(
+        type = VisitOrderType.PVO,
+        status = VisitOrderStatus.USED,
+        visitReference = visitReference,
+        prisoner = dpsPrisoner,
+      ),
+    )
 
     val changeLog = ChangeLog(
       changeType = ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED,
@@ -389,8 +398,58 @@ class ProcessPrisonerServiceTest {
     processPrisonerService.processPrisonerVisitOrderRefund(visit)
 
     // THEN
+    verify(visitOrderHistoryService).logAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference, VisitOrderType.PVO.name)
     verify(changeLogService).createLogAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_REFUNDED_AFTER_VISIT_CANCELLATION), anyMap())
+  }
+
+  @Test
+  fun `Prisoner VO refund - Given associated VO cannot be refunded because prisoner is at VO cap, only history is created`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val visit = createVisitDto(visitReference, prisonerId, "HEI")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    repeat(26) {
+      dpsPrisoner.visitOrders.add(visitOrdersUtil.createAvailableVisitOrder(dpsPrisoner, VisitOrderType.VO))
+    }
+    dpsPrisoner.visitOrders.add(
+      VisitOrder(
+        type = VisitOrderType.VO,
+        status = VisitOrderStatus.USED,
+        visitReference = visitReference,
+        prisoner = dpsPrisoner,
+      ),
+    )
+
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    // WHEN
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    verify(visitOrderHistoryService).logAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference, VisitOrderType.VO.name)
+    verifyNoInteractions(changeLogService, telemetryClientService)
+  }
+
+  @Test
+  fun `Prisoner VO refund - Given session template uses no visit order, when processPrisonerVisitOrderRefund is called, only history is created`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val visit = createVisitDto(visitReference, prisonerId, "HEI")
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    // WHEN
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderRefund(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    verify(visitOrderHistoryService).logAllocationRefundedByVisitCancelled(dpsPrisoner, visitReference, "NONE")
+    verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
   // Prisoner Reset balance \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -21,12 +21,16 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.Sessi
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.PrisonerDetails
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistory
+import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.VisitOrderHistoryAttributes
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.ChangeLogService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerDetailsService
 import uk.gov.justice.digital.hmpps.visitallocationapi.service.PrisonerRetryService
@@ -329,6 +333,40 @@ class ProcessPrisonerServiceTest {
     assertThat(dpsPrisoner.negativeVisitOrders).isEmpty()
     verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference)
     verifyNoInteractions(changeLogService, telemetryClientService)
+  }
+
+  @Test
+  fun `Prisoner VO consumption - Given session template uses no visit order and visit history exists, when processPrisonerVisitOrderUsage is called, then no extra processing is done`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val prisonId = "HEI"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId)
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    val visitOrderHistory = VisitOrderHistory(
+      type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT,
+      prisoner = dpsPrisoner,
+      voBalance = 1,
+      pvoBalance = 0,
+      userName = "SYSTEM",
+    )
+    visitOrderHistory.visitOrderHistoryAttributes.add(
+      VisitOrderHistoryAttributes(
+        visitOrderHistory = visitOrderHistory,
+        attributeType = VisitOrderHistoryAttributeType.VISIT_REFERENCE,
+        attributeValue = visitReference,
+      ),
+    )
+    dpsPrisoner.visitOrderHistory.add(visitOrderHistory)
+
+    // WHEN
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    verifyNoInteractions(visitOrderHistoryService, changeLogService, telemetryClientService)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -285,6 +285,7 @@ class ProcessPrisonerServiceTest {
     val prisonId = "HEI"
     val visit = createVisitDto(visitReference, prisonerId, prisonId)
     val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    dpsPrisoner.visitOrders.add(visitOrdersUtil.createAvailableVisitOrder(dpsPrisoner, VisitOrderType.PVO))
 
     val changeLog = ChangeLog(
       changeType = ChangeLogType.ALLOCATION_USED_BY_VISIT,
@@ -305,6 +306,7 @@ class ProcessPrisonerServiceTest {
     processPrisonerService.processPrisonerVisitOrderUsage(visit)
 
     // THEN
+    verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference, VisitOrderType.PVO.name)
     verify(changeLogService).createLogAllocationUsedByVisit(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_CONSUMED_BY_VISIT), anyMap())
   }
@@ -328,7 +330,7 @@ class ProcessPrisonerServiceTest {
     assertThat(changeLogReference).isNull()
     assertThat(dpsPrisoner.visitOrders).allMatch { it.status == VisitOrderStatus.AVAILABLE && it.visitReference == null }
     assertThat(dpsPrisoner.negativeVisitOrders).isEmpty()
-    verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference)
+    verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference, "NONE")
     verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
@@ -350,7 +352,7 @@ class ProcessPrisonerServiceTest {
     // THEN
     assertThat(changeLogReference).isNull()
     verify(visitOrderHistoryService).allocationUsedByVisitExists(prisonerId, visitReference)
-    verify(visitOrderHistoryService, never()).logAllocationUsedByVisit(dpsPrisoner, visitReference)
+    verify(visitOrderHistoryService, never()).logAllocationUsedByVisit(dpsPrisoner, visitReference, "NONE")
     verifyNoInteractions(changeLogService, telemetryClientService)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/ProcessPrisonerServiceTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi
 
 import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -9,15 +10,19 @@ import org.mockito.Mockito.anyMap
 import org.mockito.Mockito.verify
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.IncentivesClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.clients.PrisonerSearchClient
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonIncentiveAmountsDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.incentives.PrisonerIncentivesDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.PrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.TelemetryEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.ChangeLogSource
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.nomis.PrisonerReceivedReasonType
 import uk.gov.justice.digital.hmpps.visitallocationapi.model.entity.ChangeLog
@@ -301,6 +306,29 @@ class ProcessPrisonerServiceTest {
     // THEN
     verify(changeLogService).createLogAllocationUsedByVisit(dpsPrisoner, visitReference)
     verify(telemetryClientService).trackEvent(eq(TelemetryEventType.VO_CONSUMED_BY_VISIT), anyMap())
+  }
+
+  @Test
+  fun `Prisoner VO consumption - Given session template uses no visit order, when processPrisonerVisitOrderUsage is called, then only history is created`() {
+    // GIVEN
+    val visitReference = "ab-cd-ef-gh"
+    val prisonerId = "AA123456"
+    val prisonId = "HEI"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId)
+    val dpsPrisoner = PrisonerDetails(prisonerId, LocalDate.now().minusDays(14), null)
+    dpsPrisoner.visitOrders.add(visitOrdersUtil.createAvailableVisitOrder(dpsPrisoner, VisitOrderType.VO))
+
+    // WHEN
+    whenever(prisonerDetailsService.getPrisonerDetailsWithLock(prisonerId)).thenReturn(dpsPrisoner)
+
+    val changeLogReference = processPrisonerService.processPrisonerVisitOrderUsage(visit, SessionTemplateVisitOrderRestrictionType.NONE)
+
+    // THEN
+    assertThat(changeLogReference).isNull()
+    assertThat(dpsPrisoner.visitOrders).allMatch { it.status == VisitOrderStatus.AVAILABLE && it.visitReference == null }
+    assertThat(dpsPrisoner.negativeVisitOrders).isEmpty()
+    verify(visitOrderHistoryService).logAllocationUsedByVisit(dpsPrisoner, visitReference)
+    verifyNoInteractions(changeLogService, telemetryClientService)
   }
 
   // Prisoner VO Refund By Visit Cancelled \\

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.Sessi
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_REFERENCE
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
@@ -95,7 +96,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.PVO.name))
   }
 
   @Test
@@ -159,7 +160,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to "NONE"))
   }
 
   @Test
@@ -223,7 +224,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.PVO.name))
   }
 
   @Test
@@ -284,7 +285,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test
@@ -347,7 +348,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = -1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = -1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -90,8 +90,8 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(2)
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
-    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changeLog.comment).isEqualTo("allocated to $visitReference")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -218,8 +218,8 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(2)
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
-    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changeLog.comment).isEqualTo("allocated to $visitReference")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -279,8 +279,8 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(1)
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
-    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changeLog.comment).isEqualTo("allocated to $visitReference")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -342,8 +342,8 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     assertThat(negativeVisitOrders.size).isEqualTo(1)
     assertThat(negativeVisitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
-    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changeLog.comment).isEqualTo("allocated to $visitReference")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -516,10 +516,10 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(1)
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
 
-    val changLogs = changeLogRepository.findAll()
-    assertThat(changLogs.size).isEqualTo(1)
+    val changeLogs = changeLogRepository.findAll()
+    assertThat(changeLogs.size).isEqualTo(1)
 
-    assertThat(changLogs[0].comment).isEqualTo("allocated to $visitReference")
+    assertThat(changeLogs[0].comment).isEqualTo("allocated to $visitReference")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -163,6 +163,70 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
   }
 
   @Test
+  fun `when domain event visit booked is found and session template is not found, then PVO is consumed`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "missing-session-template-ref"
+
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.VO, 2, dpsPrisoner))
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.PVO, 1, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(
+      ChangeLog(
+        changeTimestamp = LocalDateTime.now().minusSeconds(1),
+        changeType = ChangeLogType.BATCH_PROCESS,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Random existing changeLog",
+        prisoner = dpsPrisoner,
+        visitOrderBalance = 2,
+        privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
+      ),
+    )
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_BOOKED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_BOOKED_EVENT_TYPE.value, domainEvent)
+
+    // And
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, null, HttpStatus.NOT_FOUND)
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
+    await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
+    await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(2)
+    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
+
+    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
+    assertThat(changLog.comment).isEqualTo("allocated to $visitReference")
+
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList.size).isEqualTo(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+  }
+
+  @Test
   fun `when domain event visit booked is found, and no PVO is available, then VO is consumed`() {
     // Given
     val visitReference = "ab-cd-ef-gh"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -164,7 +164,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
   }
 
   @Test
-  fun `when domain event visit booked is found and session template is not found, then PVO is consumed`() {
+  fun `when domain event visit booked is found and session template is not found, then message is sent to DLQ`() {
     // Given
     val visitReference = "ab-cd-ef-gh"
     val prisonId = "HEI"
@@ -207,24 +207,21 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     awsSnsClient.publish(publishRequest).get()
 
     // Then
-    await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
-    await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
-    await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
-    await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
-
     await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+    await untilCallTo { domainEventsSqsDlqClient!!.countMessagesOnQueue(domainEventsDlqUrl!!).get() } matches { it == 1 }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
+    await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
+    await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
     val visitOrders = visitOrderRepository.findAll()
-    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(2)
-    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(1)
+    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(3)
+    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
 
-    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }
-    assertThat(changeLog.comment).isEqualTo("allocated to $visitReference")
+    val changeLogs = changeLogRepository.findAll()
+    assertThat(changeLogs.none { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }).isTrue()
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
-    assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.PVO.name))
+    assertThat(visitOrderHistoryList.size).isEqualTo(0)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitBookedTest.kt
@@ -8,9 +8,13 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_REFERENCE
@@ -76,7 +80,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -92,6 +96,70 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
     assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
+  }
+
+  @Test
+  fun `when domain event visit booked is found and session template uses no visit order, then only history is created`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "session-template-ref"
+
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.VO, 2, dpsPrisoner))
+    dpsPrisoner.visitOrders.addAll(createVisitOrders(VisitOrderType.PVO, 1, dpsPrisoner))
+    dpsPrisoner.changeLogs.add(
+      ChangeLog(
+        changeTimestamp = LocalDateTime.now().minusSeconds(1),
+        changeType = ChangeLogType.BATCH_PROCESS,
+        changeSource = ChangeLogSource.SYSTEM,
+        userId = "SYSTEM",
+        comment = "Random existing changeLog",
+        prisoner = dpsPrisoner,
+        visitOrderBalance = 2,
+        privilegedVisitOrderBalance = 1,
+        reference = UUID.randomUUID(),
+      ),
+    )
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_BOOKED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_BOOKED_EVENT_TYPE.value, domainEvent)
+
+    // And
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, SessionTemplateDto(SessionTemplateVisitOrderRestrictionType.NONE))
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), eq(SessionTemplateVisitOrderRestrictionType.NONE)) }
+    await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
+    await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(3)
+    assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
+
+    val changeLogs = changeLogRepository.findAll()
+    assertThat(changeLogs.none { it.changeType == ChangeLogType.ALLOCATION_USED_BY_VISIT }).isTrue()
+
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList.size).isEqualTo(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_USED_BY_VISIT, attributes = mapOf(VISIT_REFERENCE to visitReference))
   }
 
   @Test
@@ -137,7 +205,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -197,7 +265,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -260,7 +328,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -312,7 +380,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -374,7 +442,7 @@ class DomainEventsVisitBookedTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderUsage(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationUsedByVisit(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
@@ -98,8 +98,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     assertThat(visitOrders.first { it.type == VisitOrderType.VO }.createdTimestamp.toLocalDate()).isEqualTo(LocalDate.now().minusDays(1))
     assertThat(visitOrders.filter { it.visitReference == visitReference }.size).isEqualTo(0)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
-    assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
+    assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -170,8 +170,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
-    assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
+    assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
     assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 0, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference))
@@ -250,8 +250,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(2)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
-    assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
+    assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -296,8 +296,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(1)
 
-    val changLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
-    assertThat(changLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
+    val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
+    assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
@@ -531,8 +531,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     val visitOrders = visitOrderRepository.findAll()
     assertThat(visitOrders.filter { it.status == VisitOrderStatus.AVAILABLE }.size).isEqualTo(26)
 
-    val changLogCount = changeLogRepository.findAll().count { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
-    assertThat(changLogCount).isEqualTo(0)
+    val changeLogCount = changeLogRepository.findAll().count { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
+    assertThat(changeLogCount).isEqualTo(0)
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(0)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
@@ -164,6 +164,45 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
   }
 
   @Test
+  fun `when duplicate visit cancelled events are found and session template uses no visit order, then history is only created once`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "session-template-ref"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value, domainEvent)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, SessionTemplateDto(SessionTemplateVisitOrderRestrictionType.NONE))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(2)).processPrisonerVisitOrderRefund(any(), eq(SessionTemplateVisitOrderRestrictionType.NONE)) }
+    await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
+    await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList).hasSize(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 0, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to "NONE"))
+  }
+
+  @Test
   fun `when domain event visit cancelled is found and session template lookup fails, then message is sent to DLQ`() {
     // Given
     val visitReference = "ab-cd-ef-gh"
@@ -336,13 +375,14 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     val negativeVisitOrders = negativeVisitOrderRepository.findAll()
     assertThat(negativeVisitOrders.size).isEqualTo(2)
+    assertThat(negativeVisitOrders).allMatch { it.status == NegativeVisitOrderStatus.REPAID }
 
     val changeLog = changeLogRepository.findAll().first { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }
     assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = -1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 0, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/DomainEventsVisitCancelledTest.kt
@@ -8,13 +8,18 @@ import org.awaitility.kotlin.untilCallTo
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.springframework.http.HttpStatus
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.prisoner.search.AttributeSearchPrisonerDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateVisitOrderRestrictionType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.ChangeLogType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.DomainEventType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.NegativeVisitOrderStatus
+import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_ORDER_TYPE_USED
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryAttributeType.VISIT_REFERENCE
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderHistoryType
 import uk.gov.justice.digital.hmpps.visitallocationapi.enums.VisitOrderStatus
@@ -87,7 +92,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -103,7 +108,89 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
+  }
+
+  @Test
+  fun `when domain event visit cancelled is found and session template uses no visit order, then no refund is processed`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "session-template-ref"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val dpsPrisoner = PrisonerDetails(prisonerId = prisonerId, lastVoAllocatedDate = LocalDate.now(), LocalDate.now())
+    dpsPrisoner.visitOrders.add(
+      VisitOrder(
+        type = VisitOrderType.VO,
+        status = VisitOrderStatus.AVAILABLE,
+        createdTimestamp = LocalDateTime.now().minusDays(1),
+        prisoner = dpsPrisoner,
+      ),
+    )
+    prisonerDetailsRepository.saveAndFlush(dpsPrisoner)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value, domainEvent)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, SessionTemplateDto(SessionTemplateVisitOrderRestrictionType.NONE))
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
+    await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), eq(SessionTemplateVisitOrderRestrictionType.NONE)) }
+    await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
+    await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
+
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+
+    val visitOrders = visitOrderRepository.findAll()
+    assertThat(visitOrders).hasSize(1)
+    assertThat(visitOrders.single().status).isEqualTo(VisitOrderStatus.AVAILABLE)
+    assertThat(changeLogRepository.findAll().none { it.changeType == ChangeLogType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED }).isTrue()
+    val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+    assertThat(visitOrderHistoryList).hasSize(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to "NONE"))
+  }
+
+  @Test
+  fun `when domain event visit cancelled is found and session template lookup fails, then message is sent to DLQ`() {
+    // Given
+    val visitReference = "ab-cd-ef-gh"
+    val prisonId = "HEI"
+    val prisonerId = "AA123456"
+    val sessionTemplateReference = "missing-session-template-ref"
+    val visit = createVisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
+
+    val domainEvent = createDomainEventJson(
+      DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value,
+      createVisitBookedAdditionalInformationJson(visitReference),
+    )
+    val publishRequest = createDomainEventPublishRequest(DomainEventType.VISIT_CANCELLED_EVENT_TYPE.value, domainEvent)
+
+    prisonerSearchMockServer.stubGetPrisonerById(prisonerId = prisonerId, createPrisonerDto(prisonerId = prisonerId, prisonId = prisonId, inOutStatus = "IN", convictedStatus = "Convicted"))
+    visitSchedulerMockServer.stubGetVisitByReference(visitReference, visit)
+    visitSchedulerMockServer.stubGetSessionTemplateByReference(sessionTemplateReference, null, HttpStatus.INTERNAL_SERVER_ERROR)
+    prisonApiMockServer.stubGetPrisonEnabledForDps(prisonId, true)
+
+    // When
+    awsSnsClient.publish(publishRequest).get()
+
+    // Then
+    await untilCallTo { domainEventsSqsClient.countMessagesOnQueue(domainEventsQueueUrl).get() } matches { it == 0 }
+    await untilCallTo { domainEventsSqsDlqClient!!.countMessagesOnQueue(domainEventsDlqUrl!!).get() } matches { it == 1 }
+    verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any(), anyOrNull())
+    assertThat(visitOrderHistoryRepository.findAll()).isEmpty()
   }
 
   @Test
@@ -158,7 +245,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -174,7 +261,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     assertThat(changeLog.comment).isEqualTo("allocated refunded as $visitReference cancelled")
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 0, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 0, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test
@@ -238,7 +325,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -255,7 +342,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = -1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = -1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test
@@ -287,7 +374,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(2)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(2)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(1)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(1)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -301,7 +388,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
     assertThat(visitOrderHistoryList.size).isEqualTo(1)
-    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference))
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test
@@ -468,7 +555,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -522,7 +609,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     // Then (first to spy verify calls twice, because at the end of the processing, we raise an event on the same queue which is read but ignored).
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(1)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -535,7 +622,8 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
     assertThat(changeLogCount).isEqualTo(0)
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
-    assertThat(visitOrderHistoryList.size).isEqualTo(0)
+    assertThat(visitOrderHistoryList).hasSize(1)
+    assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisonerId, comment = null, voBalance = 26, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.ALLOCATION_REFUNDED_BY_VISIT_CANCELLED, attributes = mapOf(VISIT_REFERENCE to visitReference, VISIT_ORDER_TYPE_USED to VisitOrderType.VO.name))
   }
 
   @Test
@@ -563,7 +651,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 
@@ -601,7 +689,7 @@ class DomainEventsVisitCancelledTest : EventsIntegrationTestBase() {
 
     await untilAsserted { verify(domainEventListenerSpy, times(1)).processMessage(any()) }
     await untilAsserted { verify(domainEventListenerServiceSpy, times(1)).handleMessage(any()) }
-    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any()) }
+    await untilAsserted { verify(processPrisonerService, times(0)).processPrisonerVisitOrderRefund(any(), anyOrNull()) }
     await untilAsserted { verify(changeLogService, times(0)).createLogAllocationRefundedByVisitCancelled(any(), any()) }
     await untilAsserted { verify(snsService, times(0)).sendPrisonAllocationAdjustmentCreatedEvent(any()) }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/EventsIntegrationTestBase.kt
@@ -244,7 +244,12 @@ abstract class EventsIntegrationTestBase {
 
   protected fun createVisitBalancesDto(remainingVo: Int, remainingPvo: Int, latestIepAdjustDate: LocalDate? = null, latestPrivIepAdjustDate: LocalDate? = null): VisitBalancesDto = VisitBalancesDto(remainingVo, remainingPvo, latestIepAdjustDate, latestPrivIepAdjustDate)
 
-  protected fun createVisitDto(visitReference: String, prisonerId: String, prisonId: String): VisitDto = VisitDto(visitReference, prisonerId, prisonId)
+  protected fun createVisitDto(
+    visitReference: String,
+    prisonerId: String,
+    prisonId: String,
+    sessionTemplateReference: String? = null,
+  ): VisitDto = VisitDto(visitReference, prisonerId, prisonId, sessionTemplateReference)
 
   private fun createAdditionalInformationJson(jsonValues: Map<String, Any>): String {
     val builder = StringBuilder()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/VisitSchedulerMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/wiremock/VisitSchedulerMockServer.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.SessionTemplateDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.dto.visit.scheduler.VisitDto
 import uk.gov.justice.digital.hmpps.visitallocationapi.integration.wiremock.MockUtils.Companion.getJsonString
 
@@ -32,6 +33,30 @@ class VisitSchedulerMockServer : WireMockServer(8097) {
             responseBuilder
               .withStatus(HttpStatus.OK.value())
               .withBody(getJsonString(visit))
+          },
+        ),
+    )
+  }
+
+  fun stubGetSessionTemplateByReference(sessionTemplateReference: String, sessionTemplate: SessionTemplateDto?, httpStatus: HttpStatus? = null) {
+    val responseBuilder = aResponse()
+      .withHeader("Content-Type", MediaType.APPLICATION_JSON_VALUE)
+
+    stubFor(
+      get("/admin/session-templates/$sessionTemplateReference")
+        .willReturn(
+          if (sessionTemplate == null) {
+            if (httpStatus != null) {
+              responseBuilder
+                .withStatus(httpStatus.value())
+            } else {
+              responseBuilder
+                .withStatus(HttpStatus.NOT_FOUND.value())
+            }
+          } else {
+            responseBuilder
+              .withStatus(HttpStatus.OK.value())
+              .withBody(getJsonString(sessionTemplate))
           },
         ),
     )


### PR DESCRIPTION
## Not Ready For Merge ##
Can only be merged once frontend is ready.

## What does this PR do?
This PR add the initial framework / logic to handle session specific visit order rules. Currently there are 4 session VO restrictions (VO, PVO, NONE, BOTH). For now we'll add the framework to get this from the visit-scheduler and also implement the logic to handle the NONE option.

- When none is selected, do not deduct a visit order. However, still log to the "visit_order_history" table as per ticket AC.
- If no session VO restriction can be fetched then default to "NULL" which will fallback to the original logic in place before this change.
- When logging to the "visit_order_history", add a new attribute of "VISIT_ORDER_TYPE_USED" which will be used to capture what vo type was taken (NONE / PVO / VO).
- Update the visit refund flow to add duplicate message delivery protections and skip refund if the session vo restriction is NONE.
- Update all test coverage.

### Other related changes in this PR
- Add a migration to the visit_order_history_attributes table, to move away from the ordinance values (0 .. 4) and instead use the enumerated string value, as we do in all other areas of our API.

## JIRA Links
https://dsdmoj.atlassian.net/browse/VB-6495