### PR TITLE
Update error retry timeouts

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -10,5 +10,10 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
 version: v1.25.1
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
-ignore: {}
+ignore:
+  SNYK-JAVA-IOOPENTELEMETRY-17280222:
+    - '*':
+        reason: Suppression for baggage limits issue as we use header size limits
+        expires: 2026-07-11T00:00:00.000Z
+        created: 2026-06-11T07:38:00.250Z
 patch: {}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,6 +93,7 @@ hmpps:
   sqs:
     enabled: ${hmpps.sqs.enabled}
     queueAdminRole: ROLE_VISIT_ALLOCATION_EVENTS_QUEUE_ADMIN
+    defaultErrorVisibilityTimeout: 20, 40, 120, 1230
 
 domain-event-processing:
     enabled: ${SQS_DOMAIN_EVENT_PROCESSING_ENABLED}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -39,6 +39,7 @@ hmpps:
   sqs:
     enabled: true
     provider: localstack
+    defaultErrorVisibilityTimeout: 0
     queues:
       prisonvisitsallocationevents:
         queueName: ${random.uuid}


### PR DESCRIPTION
## What does this PR do?

fail -> wait 20s
fail -> wait 40s
fail -> wait 2m
fail -> wait ~20.5m each time

with redrive policy set to 36, DLQ after ~11h (up to 12hrs with some jitter in between processing. Which aligns with terraform).