### PR TITLE
Continued SQS queue config changes

### DIFF
--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -71,8 +71,7 @@ generic-service:
       - internal
 
   retryDlqCronjob:
-    enabled: true
-    retryDlqSchedule: "*/15 * * * *" # Override to every 15 minutes for the DLQ retry. Allows for downstream API issues to resolve before retrying.
+    enabled: false
 
 generic-prometheus-alerts:
   targetApplication: hmpps-visit-allocation-api

--- a/helm_deploy/hmpps-visit-allocation-api/values.yaml
+++ b/helm_deploy/hmpps-visit-allocation-api/values.yaml
@@ -73,6 +73,11 @@ generic-service:
   retryDlqCronjob:
     enabled: false
 
+  batchjobs:
+    - name: retry-events-dlq
+      type: RETRY_EVENTS_DLQ
+      schedule: "*/15 * * * *"
+
 generic-prometheus-alerts:
   targetApplication: hmpps-visit-allocation-api
 

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -32,9 +32,7 @@ generic-prometheus-alerts:
   sqsAlertsQueueNames:
     - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_events_queue"
     - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_events_dlq"
-    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_processing_job_queue"
     - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_processing_job_dlq"
-    - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_prisoner_retry_queue"
     - "book-a-prison-visit-dev-hmpps_prison_visits_allocation_prisoner_retry_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -27,9 +27,7 @@ generic-prometheus-alerts:
   sqsAlertsQueueNames:
     - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_events_queue"
     - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_events_dlq"
-    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_processing_job_queue"
     - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_processing_job_dlq"
-    - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_prisoner_retry_queue"
     - "book-a-prison-visit-preprod-hmpps_prison_visits_allocation_prisoner_retry_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -35,9 +35,7 @@ generic-prometheus-alerts:
   sqsAlertsQueueNames:
     - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_events_queue"
     - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_events_dlq"
-    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_processing_job_queue"
     - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_processing_job_dlq"
-    - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_prisoner_retry_queue"
     - "book-a-prison-visit-prod-hmpps_prison_visits_allocation_prisoner_retry_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/helm_deploy/values-staging.yaml
+++ b/helm_deploy/values-staging.yaml
@@ -32,9 +32,7 @@ generic-prometheus-alerts:
   sqsAlertsQueueNames:
     - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_events_queue"
     - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_events_dlq"
-    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_processing_job_queue"
     - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_processing_job_dlq"
-    - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_prisoner_retry_queue"
     - "book-a-prison-visit-staging-hmpps_prison_visits_allocation_prisoner_retry_dlq"
   sqsAlertsOldestThreshold: 1
   sqsAlertsTotalMessagesThreshold: 1

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationApi.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationApi.kt
@@ -1,11 +1,40 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi
 
+import org.springframework.boot.SpringApplication
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration
 import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.data.jpa.autoconfigure.DataJpaRepositoriesAutoConfiguration
+import org.springframework.boot.flyway.autoconfigure.FlywayAutoConfiguration
+import org.springframework.boot.hibernate.autoconfigure.HibernateJpaAutoConfiguration
+import org.springframework.boot.jdbc.autoconfigure.DataSourceAutoConfiguration
+import org.springframework.boot.jdbc.autoconfigure.DataSourceTransactionManagerAutoConfiguration
 import org.springframework.boot.runApplication
+import org.springframework.context.annotation.ComponentScan
+import org.springframework.context.annotation.Configuration
+import uk.gov.justice.digital.hmpps.visitallocationapi.batch.BatchManager
 
 @SpringBootApplication
 class VisitAllocationApi
 
+@Configuration
+@ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
+@EnableAutoConfiguration(
+  exclude = [
+    DataSourceAutoConfiguration::class,
+    DataSourceTransactionManagerAutoConfiguration::class,
+    FlywayAutoConfiguration::class,
+    HibernateJpaAutoConfiguration::class,
+    DataJpaRepositoriesAutoConfiguration::class,
+  ],
+)
+@ComponentScan(basePackageClasses = [BatchManager::class])
+class VisitAllocationBatchApi
+
 fun main(args: Array<String>) {
-  runApplication<VisitAllocationApi>(*args)
+  if (System.getenv("BATCH_ENABLED").equals("true", ignoreCase = true)) {
+    SpringApplication.run(VisitAllocationBatchApi::class.java, *args)
+  } else {
+    runApplication<VisitAllocationApi>(*args)
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/BatchManager.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/BatchManager.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.batch
+
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.event.ContextRefreshedEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Service
+
+enum class BatchType {
+  RETRY_EVENTS_DLQ,
+}
+
+@ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
+@Service
+class BatchManager(
+  @param:Value("\${batch.type}") private val batchType: BatchType,
+  private val retryEventsDlqService: RetryEventsDlqService,
+) {
+  companion object {
+    private val LOG = LoggerFactory.getLogger(this::class.java)
+  }
+
+  @EventListener
+  fun onApplicationEvent(event: ContextRefreshedEvent) = runBatchJob(batchType)
+    .also { event.closeApplication() }
+
+  fun runBatchJob(batchType: BatchType) = runBlocking {
+    LOG.info("Running batch job type {}", batchType)
+    when (batchType) {
+      BatchType.RETRY_EVENTS_DLQ -> retryEventsDlqService.retryEventsDlqMessages()
+    }
+    LOG.info("Finished batch job type {}", batchType)
+  }
+
+  private fun ContextRefreshedEvent.closeApplication() = (this.applicationContext as ConfigurableApplicationContext).close()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/RetryEventsDlqService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/RetryEventsDlqService.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.batch
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener.Companion.PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.RetryDlqRequest
+import uk.gov.justice.hmpps.sqs.RetryDlqResult
+
+@Service
+class RetryEventsDlqService(
+  private val hmppsQueueService: HmppsQueueService,
+) {
+  companion object {
+    private val LOG = LoggerFactory.getLogger(this::class.java)
+  }
+
+  suspend fun retryEventsDlqMessages(): RetryDlqResult {
+    val queue = hmppsQueueService.findByQueueId(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY)
+      ?: throw IllegalArgumentException("Queue $PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY not found")
+
+    return hmppsQueueService.retryDlqMessages(RetryDlqRequest(queue))
+      .also { LOG.info("Retried {} messages from events DLQ", it.messagesFoundCount) }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/SqsListenerSuppressor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/SqsListenerSuppressor.kt
@@ -1,16 +1,15 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi.batch
 
+import io.awspring.cloud.sqs.annotation.SqsListener
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.config.BeanFactoryPostProcessor
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
 import org.springframework.beans.factory.support.DefaultListableBeanFactory
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener
 
 /**
- * This batch job moves messages from the events DLQ back to the events queue. Remove the events listener in batch mode
- * so the short-lived batch pod does not consume the same messages it has just retried.
+ * Batch jobs run in short-lived pods, so remove all SQS listener beans in batch mode to stop the pod consuming queues.
  */
 @Component
 @ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
@@ -21,19 +20,20 @@ class SqsListenerSuppressor : BeanFactoryPostProcessor {
 
   override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
     (beanFactory as DefaultListableBeanFactory).beanDefinitionNames
-      .filter { beanName -> beanFactory.isBeanAssignableFrom<DomainEventListener>(beanName) }
+      .filter { beanName -> beanFactory.hasSqsListener(beanName) }
       .forEach {
-        LOG.info("Removing events listener bean {} for batch job", it)
+        LOG.info("Removing SQS listener bean {} for batch job", it)
         beanFactory.removeBeanDefinition(it)
       }
   }
 
-  private inline fun <reified T> DefaultListableBeanFactory.isBeanAssignableFrom(beanName: String): Boolean {
-    getBeanDefinition(beanName).beanClassName
+  private fun DefaultListableBeanFactory.hasSqsListener(beanName: String): Boolean {
+    val beanClass = getBeanDefinition(beanName).beanClassName
       ?.let { runCatching { Class.forName(it, false, beanClassLoader) }.getOrNull() }
-      ?.let { return T::class.java.isAssignableFrom(it) }
+      ?: runCatching { getType(beanName, false) }.getOrNull()
 
-    return runCatching { getType(beanName, false) }.getOrNull()
-      ?.let { T::class.java.isAssignableFrom(it) } == true
+    return beanClass
+      ?.methods
+      ?.any { it.isAnnotationPresent(SqsListener::class.java) } == true
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/SqsListenerSuppressor.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/batch/SqsListenerSuppressor.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi.batch
+
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.beans.factory.support.DefaultListableBeanFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener
+
+/**
+ * This batch job moves messages from the events DLQ back to the events queue. Remove the events listener in batch mode
+ * so the short-lived batch pod does not consume the same messages it has just retried.
+ */
+@Component
+@ConditionalOnProperty(name = ["batch.enabled"], havingValue = "true")
+class SqsListenerSuppressor : BeanFactoryPostProcessor {
+  companion object {
+    private val LOG = LoggerFactory.getLogger(this::class.java)
+  }
+
+  override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+    (beanFactory as DefaultListableBeanFactory).beanDefinitionNames
+      .filter { beanName -> beanFactory.isBeanAssignableFrom<DomainEventListener>(beanName) }
+      .forEach {
+        LOG.info("Removing events listener bean {} for batch job", it)
+        beanFactory.removeBeanDefinition(it)
+      }
+  }
+
+  private inline fun <reified T> DefaultListableBeanFactory.isBeanAssignableFrom(beanName: String): Boolean {
+    getBeanDefinition(beanName).beanClassName
+      ?.let { runCatching { Class.forName(it, false, beanClassLoader) }.getOrNull() }
+      ?.let { return T::class.java.isAssignableFrom(it) }
+
+    return runCatching { getType(beanName, false) }.getOrNull()
+      ?.let { T::class.java.isAssignableFrom(it) } == true
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,7 +93,23 @@ hmpps:
   sqs:
     enabled: ${hmpps.sqs.enabled}
     queueAdminRole: ROLE_VISIT_ALLOCATION_EVENTS_QUEUE_ADMIN
-    defaultErrorVisibilityTimeout: 20, 40, 120, 1230
+    # Default failed-message retry delay. With maxReceiveCount=3 this gives the domain events queue around 30 minutes before DLQ.
+    defaultErrorVisibilityTimeout:
+      - 900
+      - 900
+    queues:
+      # Individual prisoner retries should run for several hours, then stay on the DLQ for manual review.
+      prisonvisitsallocationprisonerretryqueue:
+        errorVisibilityTimeout:
+          - 20
+          - 40
+          - 120
+          - 840
+      # Per-prison nightly jobs get two 10-minute retries, then DLQ well before the next scheduled run.
+      visitsallocationeventjob:
+        errorVisibilityTimeout:
+          - 600
+          - 600
 
 domain-event-processing:
     enabled: ${SQS_DOMAIN_EVENT_PROCESSING_ENABLED}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -105,11 +105,11 @@ hmpps:
           - 40
           - 120
           - 840
-      # Per-prison nightly jobs get two 10-minute retries, then DLQ well before the next scheduled run.
+      # Per-prison nightly jobs get two 30-minute retries, then DLQ well before the next scheduled run.
       visitsallocationeventjob:
         errorVisibilityTimeout:
-          - 600
-          - 600
+          - 1800
+          - 1800
 
 domain-event-processing:
     enabled: ${SQS_DOMAIN_EVENT_PROCESSING_ENABLED}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,11 +93,15 @@ hmpps:
   sqs:
     enabled: ${hmpps.sqs.enabled}
     queueAdminRole: ROLE_VISIT_ALLOCATION_EVENTS_QUEUE_ADMIN
-    # Default failed-message retry delay. With maxReceiveCount=3 this gives the domain events queue around 30 minutes before DLQ.
+    # Fallback failed-message retry delay. Queues with operational retry requirements should define their own timeout below.
     defaultErrorVisibilityTimeout:
-      - 900
-      - 900
+      - 0
     queues:
+      # Domain events retry for around 2 hours, then DLQ before the 3-hour source queue retention expires.
+      prisonvisitsallocationevents:
+        errorVisibilityTimeout:
+          - 3600
+          - 3600
       # Individual prisoner retries should run for several hours, then stay on the DLQ for manual review.
       prisonvisitsallocationprisonerretryqueue:
         errorVisibilityTimeout:
@@ -105,11 +109,11 @@ hmpps:
           - 40
           - 120
           - 840
-      # Per-prison nightly jobs get two 30-minute retries, then DLQ well before the next scheduled run.
+      # Per-prison nightly jobs get two 90-minute retries, then DLQ well before the next scheduled run.
       visitsallocationeventjob:
         errorVisibilityTimeout:
-          - 1800
-          - 1800
+          - 5400
+          - 5400
 
 domain-event-processing:
     enabled: ${SQS_DOMAIN_EVENT_PROCESSING_ENABLED}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -95,13 +95,15 @@ hmpps:
     queueAdminRole: ROLE_VISIT_ALLOCATION_EVENTS_QUEUE_ADMIN
     # Fallback failed-message retry delay. Queues with operational retry requirements should define their own timeout below.
     defaultErrorVisibilityTimeout:
-      - 0
+      - 10
+      - 20
+      - 40
+      - 60
     queues:
-      # Domain events retry for around 2 hours, then DLQ before the 3-hour source queue retention expires.
+      # Domain events fail quickly to the DLQ; the retry-events-dlq batch job retries that DLQ every 15 minutes.
       prisonvisitsallocationevents:
         errorVisibilityTimeout:
-          - 3600
-          - 3600
+          - 0
       # Individual prisoner retries should run for several hours, then stay on the DLQ for manual review.
       prisonvisitsallocationprisonerretryqueue:
         errorVisibilityTimeout:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationBatchApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationBatchApiTest.kt
@@ -1,0 +1,90 @@
+package uk.gov.justice.digital.hmpps.visitallocationapi
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+import org.springframework.transaction.PlatformTransactionManager
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import uk.gov.justice.digital.hmpps.visitallocationapi.batch.BatchManager
+import uk.gov.justice.digital.hmpps.visitallocationapi.batch.RetryEventsDlqService
+import uk.gov.justice.digital.hmpps.visitallocationapi.batch.SqsListenerSuppressor
+import uk.gov.justice.digital.hmpps.visitallocationapi.repository.PrisonerDetailsRepository
+import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEventListener.Companion.PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY
+import uk.gov.justice.hmpps.sqs.HmppsQueue
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
+import uk.gov.justice.hmpps.sqs.RetryDlqResult
+import jakarta.persistence.EntityManagerFactory
+import org.flywaydb.core.Flyway
+import javax.sql.DataSource
+
+class VisitAllocationBatchApiTest {
+  private val contextRunner = ApplicationContextRunner({ NonClosingAnnotationConfigApplicationContext() })
+    .withUserConfiguration(VisitAllocationBatchApi::class.java)
+    .withBean(HmppsQueueService::class.java, { hmppsQueueService() })
+    .withPropertyValues(
+      "batch.enabled=true",
+      "batch.type=RETRY_EVENTS_DLQ",
+      "hmpps.sqs.enabled=false",
+      "spring.autoconfigure.exclude=uk.gov.justice.hmpps.sqs.HmppsSqsConfiguration",
+    )
+
+  @Test
+  fun `batch context is slimmed down to batch application beans`() {
+    contextRunner.run { context ->
+      val sourceContext = context.getSourceApplicationContext(NonClosingAnnotationConfigApplicationContext::class.java)
+
+      try {
+        assertThat(context).hasSingleBean(BatchManager::class.java)
+        assertThat(context).hasSingleBean(RetryEventsDlqService::class.java)
+        assertThat(context).hasSingleBean(SqsListenerSuppressor::class.java)
+        assertThat(context).doesNotHaveBean(DataSource::class.java)
+        assertThat(context).doesNotHaveBean(PlatformTransactionManager::class.java)
+        assertThat(context).doesNotHaveBean(EntityManagerFactory::class.java)
+        assertThat(context).doesNotHaveBean(Flyway::class.java)
+        assertThat(context).doesNotHaveBean(PrisonerDetailsRepository::class.java)
+
+        val visitAllocationBeans = context.beanDefinitionNames
+          .mapNotNull { beanName -> context.getType(beanName) }
+          .filter { beanClass -> beanClass.packageName.startsWith("uk.gov.justice.digital.hmpps.visitallocationapi") }
+
+        assertThat(visitAllocationBeans)
+          .allSatisfy { beanClass ->
+            assertThat(beanClass.packageName)
+              .isIn(
+                "uk.gov.justice.digital.hmpps.visitallocationapi",
+                "uk.gov.justice.digital.hmpps.visitallocationapi.batch",
+              )
+          }
+      } finally {
+        sourceContext.closeForReal()
+      }
+    }
+  }
+
+  private fun hmppsQueueService(): HmppsQueueService {
+    val hmppsQueueService = mock<HmppsQueueService>()
+    val hmppsQueue = HmppsQueue(
+      id = PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY,
+      sqsClient = mock<SqsAsyncClient>(),
+      queueName = "prison-visits-allocation-events",
+    )
+
+    whenever(hmppsQueueService.findByQueueId(PRISON_VISITS_ALLOCATION_ALERTS_QUEUE_CONFIG_KEY)).thenReturn(hmppsQueue)
+    runBlocking {
+      whenever(hmppsQueueService.retryDlqMessages(any())).thenReturn(RetryDlqResult(messagesFoundCount = 0))
+    }
+
+    return hmppsQueueService
+  }
+
+  private class NonClosingAnnotationConfigApplicationContext : AnnotationConfigApplicationContext() {
+    override fun close() = Unit
+
+    fun closeForReal() = super.close()
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationBatchApiTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/VisitAllocationBatchApiTest.kt
@@ -1,7 +1,9 @@
 package uk.gov.justice.digital.hmpps.visitallocationapi
 
+import jakarta.persistence.EntityManagerFactory
 import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
+import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -18,8 +20,6 @@ import uk.gov.justice.digital.hmpps.visitallocationapi.service.listener.DomainEv
 import uk.gov.justice.hmpps.sqs.HmppsQueue
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 import uk.gov.justice.hmpps.sqs.RetryDlqResult
-import jakarta.persistence.EntityManagerFactory
-import org.flywaydb.core.Flyway
 import javax.sql.DataSource
 
 class VisitAllocationBatchApiTest {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -113,6 +113,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
+      .sortedWith(compareBy({ it.prisoner.prisonerId }, { it.type.ordinal }))
     assertThat(visitOrderHistoryList.size).isEqualTo(3)
     assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisoner1.prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.VO_ALLOCATION, attributes = mapOf(INCENTIVE_LEVEL to "STD"))
     assertVisitOrderHistory(visitOrderHistoryList[1], prisonerId = prisoner2.prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.VO_AND_PVO_ALLOCATION, attributes = mapOf(INCENTIVE_LEVEL to "ENH"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/visitallocationapi/integration/events/VisitAllocationByPrisonJobSqsTest.kt
@@ -113,7 +113,7 @@ class VisitAllocationByPrisonJobSqsTest : EventsIntegrationTestBase() {
     assertVisitOrderAllocationPrisonJob(visitOrderAllocationPrisonJobs[0], null, convictedPrisoners = 3, processedPrisoners = 3, failedOrSkippedPrisoners = 0)
 
     val visitOrderHistoryList = visitOrderHistoryRepository.findAll()
-      .sortedWith(compareBy({ it.prisoner.prisonerId }, { it.type.ordinal }))
+      .sortedWith(compareBy({ it.prisoner.prisonerId }, { it.type }))
     assertThat(visitOrderHistoryList.size).isEqualTo(3)
     assertVisitOrderHistory(visitOrderHistoryList[0], prisonerId = prisoner1.prisonerId, comment = null, voBalance = 1, pvoBalance = 0, userName = "SYSTEM", type = VisitOrderHistoryType.VO_ALLOCATION, attributes = mapOf(INCENTIVE_LEVEL to "STD"))
     assertVisitOrderHistory(visitOrderHistoryList[1], prisonerId = prisoner2.prisonerId, comment = null, voBalance = 2, pvoBalance = 1, userName = "SYSTEM", type = VisitOrderHistoryType.VO_AND_PVO_ALLOCATION, attributes = mapOf(INCENTIVE_LEVEL to "ENH"))

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -50,9 +50,11 @@ hmpps:
       visitsallocationeventjob:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}
+        errorVisibilityTimeout: 0
       prisonvisitsallocationprisonerretryqueue:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}
+        errorVisibilityTimeout: 0
     topics:
       domainevents:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,15 +47,18 @@ hmpps:
         subscribeTopicId: domainevents
         dlqMaxReceiveCount: 1
         visibilityTimeout: 1
-        errorVisibilityTimeout: 0
+        errorVisibilityTimeout:
+          - 0
       visitsallocationeventjob:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}
-        errorVisibilityTimeout: 0
+        errorVisibilityTimeout:
+          - 0
       prisonvisitsallocationprisonerretryqueue:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}
-        errorVisibilityTimeout: 0
+        errorVisibilityTimeout:
+          - 0
     topics:
       domainevents:
         arn: arn:aws:sns:eu-west-2:000000000000:${random.uuid}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -47,6 +47,7 @@ hmpps:
         subscribeTopicId: domainevents
         dlqMaxReceiveCount: 1
         visibilityTimeout: 1
+        errorVisibilityTimeout: 0
       visitsallocationeventjob:
         queueName: ${random.uuid}
         dlqName: ${random.uuid}


### PR DESCRIPTION
## What does this PR do?
Create specific queue error visibility timeout settings and also remove the DLQ retry for 2 of the 3 queues. Because of the new timeout settings, if a message makes it into the DLQ, it should stay there for manual reviewing instead of being pushed back into the live queues.

- New queue configs
- Disable the DLQ retry and make it terminal for "per-prison queue" and "prisoner-retry queue".

- Because we've added a robust retry policy, we are removing the alerting from the main 2 queues (per-prison queue and prisoner-retry queue, because while retrying we don't want alerts). 

NOTE: We've kept the allocation-events queue alerting because anything going wrong there will need immediate attention during the day.

## Custom Batch manager
To avoid using the generic "retryAllDlq" endpoint, we have implemented a custom batch manager which calls specifically to the domain-events DLQ to retry those messages ONLY. The batch-manager pod will spin up with a lot of configurations disabled (such as DB, SQS listeners and more) to avoid taking excessive resources. It will be a slim pod with only the essentials.

## Queue Configs

| Queue | Error visibility timeout | maxReceiveCount | Approx time before DLQ | Purpose |
|---|---:|---:|---:|---|
| `prisonvisitsallocationevents` | `0` | `3` | ~0-minutes | Domain events should be processed promptly, then DLQ for manual review, and a batch manager which will retry it every 15minutes.
| `visitsallocationeventjob` | `5400, 5400` | `3` | ~3 hours | Per-prison nightly jobs retry briefly for an hour, then DLQ well before the next scheduled run. |
| `prisonvisitsallocationprisonerretryqueue` | `20, 40, 120, 840...` | `36` | ~7h 31m | Individual prisoner retries run for several hours, then DLQ for manual review. |

`prisonvisitsallocationprisonerretryqueue` calculation:
```text
20 + 40 + 120 + (32 * 840)
= 27,060 seconds
= 7h 31m